### PR TITLE
Add manual adiff and tag editing

### DIFF
--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -1,13 +1,15 @@
-import { Button, Select } from '@mui/material'
-import React, { useEffect, useState } from 'react'
+import { Button, TextField } from '@mui/material'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import GradeSelect from '../../Components/GradeSelect'
 import packs from '../../consts/packs'
 import Tesseract from 'tesseract.js'
 
-const SongDetails = ({chart, changeGrade}) => {
+const SongDetails = ({chart, changeGrade, updateDiff}) => {
     const [grade, setGrade] = useState(chart.grade || '')
     const [goal, setGoal] = useState(chart.goal || '')
+    const [adiff, setAdiff] = useState(chart.adiff || '')
+    const [tags, setTags] = useState(chart.tag ? chart.tag.join(', ') : '')
     const [selectedImage, setSelectedImage] = useState(null);
     const [recognizedText, setRecognizedText] = useState('');
     const handleImageUpload = (event) => {
@@ -64,6 +66,13 @@ const SongDetails = ({chart, changeGrade}) => {
             onChange={(e) => setGoal(e.target.value)}
         /> */}
         <div />
+        <div>
+            <TextField label="Adiff" value={adiff} onChange={e => setAdiff(e.target.value)} />
+            <TextField label="Tags (comma separated)" value={tags} onChange={e => setTags(e.target.value)} />
+            <Button onClick={() => {
+                updateDiff(chart.id, chart.mode, chart.diff, adiff, tags)
+            }}>Save</Button>
+        </div>
         <div>
             test
             <input type="file" accept="image/*" onChange={handleImageUpload} />

--- a/Frontend/src/Pages/Songs/index.jsx
+++ b/Frontend/src/Pages/Songs/index.jsx
@@ -157,7 +157,30 @@ const Songs = ({mode}) => {
             }
         } else {
             details[mode][openChart.diff] = {[openChart.id]: {grade: value} }
-        } 
+        }
+    }
+
+    const updateDiff = (songId, mode, diff, adiffValue, tagsValue) => {
+        const song = songs[songId]
+        if (!song) return
+        const obj = song.diffs.find(d => typeof d === 'object' && d.type === mode && d.diff === diff)
+        if (obj) {
+            obj.adiff = adiffValue || undefined
+            const arr = tagsValue ? tagsValue.split(',').map(t => t.trim()).filter(Boolean) : []
+            obj.tag = arr.length ? arr : undefined
+        }
+        setOpenChart({ ...openChart, adiff: obj.adiff, tag: obj.tag })
+        loadData(songs)
+    }
+
+    const downloadSongs = () => {
+        const json = JSON.stringify(songs, null, 2)
+        const blob = new Blob([json], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = 'songs_modified.json'
+        a.click()
     }
 
     const shouldDisplayDiff = (diff) => {
@@ -192,16 +215,18 @@ const Songs = ({mode}) => {
                 aria-describedby="modal-modal-description"
             >
                 <StyledBox>
-                    <SongDetails 
+                    <SongDetails
                         chart={openChart}
                         changeGrade={changeGrade}
+                        updateDiff={updateDiff}
                     />
                     
                 </StyledBox>
             </Modal>
 
             <div>
-                <StyledTextField 
+                <Button onClick={downloadSongs}>Download JSON</Button>
+                <StyledTextField
                     onChange={(e) => setSearch(e.target.value ? { ...search, title: e.target.value} : undefined)}
                     value={search?.title || ''}
                     label="Search by name"


### PR DESCRIPTION
## Summary
- allow setting adiff and tags in SongDetails
- support persisting edited data and downloading modified `songs.json`

## Testing
- `npm test` in `Server` *(fails: jest not found)*
- `npm test -- -i` in `Frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ea450e40832491e28b9c38ba09a7