### PR TITLE
Reload page when changing modes

### DIFF
--- a/Frontend/src/Components/Navigation/index.jsx
+++ b/Frontend/src/Components/Navigation/index.jsx
@@ -47,7 +47,10 @@ function NavBar() {
   };
 
   const handleCloseNavMenu = (page) => {
-    page && navigate(`/${page}`)
+    if (page) {
+      navigate(`/${page}`);
+      window.location.reload();
+    }
     setAnchorElNav(null);
   };
 


### PR DESCRIPTION
## Summary
- force page reload after selecting a new navigation item

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687523be663c83248411013a8da9fc7b