### PR TITLE
Add leaderboard page

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -18,6 +18,7 @@ export class ApiClient {
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
 
     getUsers = () => client.get('users')
+    getLeaderboard = (mode) => client.get(`leaderboard/${mode}`)
 }
 
 export default client

--- a/Frontend/src/Pages/Leaderboard/index.jsx
+++ b/Frontend/src/Pages/Leaderboard/index.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { ApiClient } from '../../API/httpService';
+import { Box, FormControl, InputLabel, MenuItem, Select, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+
+const apiClient = new ApiClient();
+
+const Leaderboard = () => {
+  const [mode, setMode] = useState('item_single');
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    apiClient.getLeaderboard(mode).then((res) => {
+      setData(res.data);
+    });
+  }, [mode]);
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <FormControl sx={{ mb: 2, minWidth: 120 }} size="small">
+        <InputLabel id="mode-select-label">Mode</InputLabel>
+        <Select labelId="mode-select-label" value={mode} label="Mode" onChange={(e) => setMode(e.target.value)}>
+          <MenuItem value={'item_single'}>Singles</MenuItem>
+          <MenuItem value={'item_double'}>Doubles</MenuItem>
+        </Select>
+      </FormControl>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>User</TableCell>
+            <TableCell align="right">Highest Pass</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell>{row.username}</TableCell>
+              <TableCell align="right">{row.highest ? `LV ${row.highest}` : '-'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+export default Leaderboard;

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -5,6 +5,7 @@ import {
 } from "react-router-dom"
 import Layout from '../Components/Layout'
 import Songs from '../Pages/Songs'
+import Leaderboard from '../Pages/Leaderboard'
 // import { useDispatch, useSelector } from 'react-redux'
 import Login from '../Pages/Login'
 
@@ -31,7 +32,7 @@ const router = createBrowserRouter([
             },
             {
                 path: 'Leaderboard',
-                element: <div>lb</div>
+                element: <Leaderboard />
             },
             {
                 path: 'add',

--- a/Server/src/controllers/index.js
+++ b/Server/src/controllers/index.js
@@ -1,3 +1,4 @@
 module.exports.authController = require('./auth.controller');
 module.exports.userController = require('./user.controller');
 module.exports.scoresController = require('./scores.controller');
+module.exports.leaderboardController = require('./leaderboard.controller');

--- a/Server/src/controllers/leaderboard.controller.js
+++ b/Server/src/controllers/leaderboard.controller.js
@@ -1,0 +1,10 @@
+const catchAsync = require('../utils/catchAsync');
+const { leaderboardService } = require('../services');
+
+const getLeaderboard = catchAsync(async (req, res) => {
+  const mode = req.params.mode;
+  const board = await leaderboardService.getLeaderboard(mode);
+  res.send(board);
+});
+
+module.exports = { getLeaderboard };

--- a/Server/src/routes/v1/index.js
+++ b/Server/src/routes/v1/index.js
@@ -3,6 +3,7 @@ const authRoute = require('./auth.route');
 const userRoute = require('./user.route');
 const docsRoute = require('./docs.route');
 const scoresRoute = require('./scores.route');
+const leaderboardRoute = require('./leaderboard.route');
 const config = require('../../config/config');
 
 const router = express.Router();
@@ -19,6 +20,10 @@ const defaultRoutes = [
   {
     path: '/scores',
     route: scoresRoute,
+  },
+  {
+    path: '/leaderboard',
+    route: leaderboardRoute,
   },
 ];
 

--- a/Server/src/routes/v1/leaderboard.route.js
+++ b/Server/src/routes/v1/leaderboard.route.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const auth = require('../../middlewares/auth');
+const leaderboardController = require('../../controllers/leaderboard.controller');
+
+const router = express.Router();
+
+router.route('/:mode').get(auth('getScores'), leaderboardController.getLeaderboard);
+
+module.exports = router;

--- a/Server/src/services/index.js
+++ b/Server/src/services/index.js
@@ -3,3 +3,4 @@ module.exports.emailService = require('./email.service');
 module.exports.tokenService = require('./token.service');
 module.exports.userService = require('./user.service');
 module.exports.scoresService = require('./scores.service');
+module.exports.leaderboardService = require('./leaderboard.service');

--- a/Server/src/services/leaderboard.service.js
+++ b/Server/src/services/leaderboard.service.js
@@ -1,0 +1,23 @@
+const prisma = require('../db');
+
+const parseLevel = (diff) => {
+  const n = parseInt(diff.replace('lv_', ''));
+  return Number.isNaN(n) ? 0 : n;
+};
+
+const getLeaderboard = async (mode) => {
+  const users = await prisma.user.findMany({ include: { scores: true } });
+  const board = users.map((u) => {
+    const scores = u.scores.filter((s) => s.mode === mode && s.grade !== 'F');
+    let highest = 0;
+    scores.forEach((s) => {
+      const level = parseLevel(s.diff);
+      if (level > highest) highest = level;
+    });
+    return { id: u.id, username: u.username, highest };
+  });
+  board.sort((a, b) => b.highest - a.highest);
+  return board;
+};
+
+module.exports = { getLeaderboard };


### PR DESCRIPTION
## Summary
- implement API service for leaderboard
- expose `/leaderboard/:mode` route and supporting controller/service
- add React Leaderboard page with mode selector
- wire leaderboard into router
- update frontend API client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760ce74b848324896b508682dd0980