### PR TITLE
Fix mode switch crash

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -33,9 +33,9 @@ const sortByFilters = (ar, br, diff, details, mode, sort) => {
   const b = br[1].diffs.find((v) => v.diff === diff && v.type === mode);
   switch (sort) {
     case "tier":
-      if (a === "?") return -1;
+      if (!a || !b || a.adiff === "?" || b.adiff === "?") return -1;
       if (a.adiff < b.adiff) return 1;
-      else if (a.adiff === b.bdiff) {
+      else if (a.adiff === b.adiff) {
         return 0;
       } else {
         return -1;
@@ -461,8 +461,8 @@ const Songs = ({ mode }) => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetailsStyled>
-                  {data[diff]
-                    ?.filter((a) =>
+                  {(data[diff] || [])
+                    .filter((a) =>
                       filterItems(
                         a,
                         details,


### PR DESCRIPTION
## Summary
- fix crash when switching between Single/Double routes
- guard sorting logic against undefined values

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in Server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760d48c12083249e9f39711bbe37ab