### PR TITLE
Add user profile page

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -18,6 +18,7 @@ export class ApiClient {
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
 
     getUsers = () => client.get('users')
+    getUser = (id) => client.get(`users/${id}`)
 }
 
 export default client

--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import Section from '../../Components/Layout/Section';
+import { ApiClient } from '../../API/httpService';
+import songs from '../../consts/songs.json';
+import compareGrades from '../../helpers/compareGrades';
+
+const apiClient = new ApiClient();
+
+const Profile = () => {
+  const { id } = useParams();
+  const [user, setUser] = useState(null);
+  const [scores, setScores] = useState({});
+
+  useEffect(() => {
+    if (!id) return;
+    apiClient.getUser(id).then((r) => setUser(r.data));
+    apiClient.getScores('item_single').then((r) => setScores(r.data));
+  }, [id]);
+
+  const bestPasses = [];
+  Object.entries(scores || {}).forEach(([diff, vals]) => {
+    Object.entries(vals).forEach(([songId, { grade }]) => {
+      bestPasses.push({ diff, songId, grade });
+    });
+  });
+  bestPasses.sort((a, b) => compareGrades(a.grade, b.grade));
+
+  return (
+    <div>
+      <Section header="User info">
+        {user && (
+          <div>
+            <div>Username: {user.username}</div>
+            <div>Email: {user.email}</div>
+          </div>
+        )}
+      </Section>
+      <Section header="Best passes">
+        <ul>
+          {bestPasses.slice(0, 10).map((bp) => (
+            <li key={`${bp.songId}-${bp.diff}`}>{songs[bp.songId]?.title} - {bp.grade} ({bp.diff})</li>
+          ))}
+        </ul>
+      </Section>
+      <Section header="Passes by difficulty">
+        {Object.entries(scores).map(([diff, vals]) => (
+          <div key={diff}>
+            <h4>{diff}</h4>
+            <ul>
+              {Object.entries(vals).map(([songId, { grade }]) => (
+                <li key={`${songId}-${diff}`}>{songs[songId]?.title} - {grade}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </Section>
+    </div>
+  );
+};
+
+export default Profile;

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -7,6 +7,7 @@ import Layout from '../Components/Layout'
 import Songs from '../Pages/Songs'
 // import { useDispatch, useSelector } from 'react-redux'
 import Login from '../Pages/Login'
+import Profile from '../Pages/Profile'
 
 const router = createBrowserRouter([
     {
@@ -39,7 +40,7 @@ const router = createBrowserRouter([
             },
             {
                 path: 'profile/:id',
-                element: <div>user profile</div>
+                element: <Profile />
             },
             {
                 path: 'login',


### PR DESCRIPTION
## Summary
- add Profile page for showing user info and scores
- expose `getUser` API client call
- route `/profile/:id` to new Profile component

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760d7a95b88324bc5d900e28a8548c