### PR TITLE
Add mode info in latest scores

### DIFF
--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -19,7 +19,8 @@ const Scores = () => {
         <List>
           {latest.map((s) => (
             <Item key={s.id}>
-              <strong>{s.user?.username}</strong> – {songs[s.song_id]?.title || s.song_id} [{s.diff}] :{' '}
+              <strong>{s.user?.username}</strong> – {songs[s.song_id]?.title || s.song_id} [
+              {s.mode === 'item_double' ? 'Double' : 'Single'} {s.diff}] :{' '}
               {s.grade || '-'}
             </Item>
           ))}


### PR DESCRIPTION
## Summary
- display play mode beside difficulty for latest scores list

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687618e1e2008324ab9711b0e7325268