### PR TITLE
Hide score options for guests

### DIFF
--- a/Frontend/src/Components/Navigation/index.jsx
+++ b/Frontend/src/Components/Navigation/index.jsx
@@ -110,26 +110,30 @@ function NavBar() {
                 display: { xs: "block", md: "none" },
               }}
             >
-              {pages.map((page) => (
-                <MenuItem key={page} onClick={() => handleCloseNavMenu(page)}>
-                  <Typography textAlign="center">{page}</Typography>
-                </MenuItem>
-              ))}
+              {pages
+                .filter((p) => p !== "Add Score" || localStorage.getItem("token"))
+                .map((page) => (
+                  <MenuItem key={page} onClick={() => handleCloseNavMenu(page)}>
+                    <Typography textAlign="center">{page}</Typography>
+                  </MenuItem>
+                ))}
             </Menu>
           </Box>
           <StyledLink to="/">
             <StyledLogo src={Logo} alt="Logo" />
           </StyledLink>
           <Box sx={{ flexGrow: 20, display: { xs: "none", md: "flex" } }}>
-            {pages.map((page) => (
-              <Button
-                key={page}
-                onClick={() => handleCloseNavMenu(page)}
-                sx={{ my: 2, color: "white", display: "block" }}
-              >
-                {page}
-              </Button>
-            ))}
+            {pages
+              .filter((p) => p !== "Add Score" || localStorage.getItem("token"))
+              .map((page) => (
+                <Button
+                  key={page}
+                  onClick={() => handleCloseNavMenu(page)}
+                  sx={{ my: 2, color: "white", display: "block" }}
+                >
+                  {page}
+                </Button>
+              ))}
           </Box>
           {localStorage.getItem("token") ? (
             <Box sx={{ flexGrow: 0 }}>

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -33,6 +33,8 @@ const SongDetails = ({ chart, changeGrade }) => {
     }
   };
 
+  const loggedIn = Boolean(localStorage.getItem("token"));
+
   return (
     <div>
       <div>Title: {chart.title}</div>
@@ -55,36 +57,44 @@ const SongDetails = ({ chart, changeGrade }) => {
         ))}
       </div>
 
-      <GradeSelect
-        label="Set Grade"
-        value={grade}
-        onChange={(e) => {
-          setGrade(e.target.value);
-          changeGrade(e.target.value);
-        }}
-      />
-      {grade && (
-        <Button
-          onClick={() => {
-            setGrade();
-            changeGrade();
-          }}
-        >
-          Remove
-        </Button>
+      {loggedIn && (
+        <>
+          <GradeSelect
+            label="Set Grade"
+            value={grade}
+            onChange={(e) => {
+              setGrade(e.target.value);
+              changeGrade(e.target.value);
+            }}
+          />
+          {grade && (
+            <Button
+              onClick={() => {
+                setGrade();
+                changeGrade();
+              }}
+            >
+              Remove
+            </Button>
+          )}
+        </>
       )}
       {/* <GradeSelect
             label="Set Goal"
             value={goal}
             onChange={(e) => setGoal(e.target.value)}
         /> */}
-      <div>
-        test
-        <input type="file" accept="image/*" onChange={handleImageUpload} />
-        {/* {selectedImage && <img src={selectedImage} alt="Selected" />} */}
-        {recognizedText && <div>{recognizedText}</div>}
-      </div>
-      <Button onClick={recognizeText}>Add Score</Button>
+      {loggedIn && (
+        <>
+          <div>
+            test
+            <input type="file" accept="image/*" onChange={handleImageUpload} />
+            {/* {selectedImage && <img src={selectedImage} alt="Selected" />} */}
+            {recognizedText && <div>{recognizedText}</div>}
+          </div>
+          <Button onClick={recognizeText}>Add Score</Button>
+        </>
+      )}
       {/* <Button>Add To Favorite</Button> */}
     </div>
   );


### PR DESCRIPTION
## Summary
- hide GradeSelect and Add Score button unless user is logged in
- remove Add Score link from the navigation when logged out

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in `Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762ee147248324ad1cb25f3f440edd