### PR TITLE
Add badge/title achievements

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -33,6 +33,12 @@ const Profile = () => {
           <div>
             <div>Username: {user.username}</div>
             <div>Email: {user.email}</div>
+            {user.titles?.length > 0 && (
+              <div>Title: {user.titles[user.titles.length - 1]}</div>
+            )}
+            {user.badges?.length > 0 && (
+              <div>Badges: {user.badges.join(', ')}</div>
+            )}
           </div>
         )}
       </Section>

--- a/Server/prisma/migrations/20250714160000_add_badges_titles/migration.sql
+++ b/Server/prisma/migrations/20250714160000_add_badges_titles/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "badges" TEXT[] DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "User" ADD COLUMN "titles" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -15,6 +15,8 @@ model User {
   name           String?
   role           String
   isEmailVerified Boolean @default(false)
+  badges         String[] @default([])
+  titles         String[] @default([])
   scores         Score[]
   tokens         Token[]
   createdAt      DateTime @default(now())

--- a/Server/src/consts/badges.js
+++ b/Server/src/consts/badges.js
@@ -1,0 +1,74 @@
+const songBadges = {
+  drill: [
+    { level: 1, song: 'Vook', chart: 'S15' },
+    { level: 2, song: 'Solitary 1.5', chart: 'S16' },
+    { level: 3, song: 'Gun Rock', chart: 'S17' },
+    { level: 4, song: 'Moonlight', chart: 'S18' },
+    { level: 5, song: 'Vacuum', chart: 'S19' },
+    { level: 6, song: 'Overblow', chart: 'S20' },
+    { level: 7, song: 'Sorceress Elise', chart: 'S21' },
+    { level: 8, song: 'Rock the house', chart: 'D22' },
+    { level: 9, song: 'Witch Doctor', chart: 'D23' },
+    { level: 10, song: 'Wi-Ex-Doc-Va', chart: 'D24' },
+    { level: 'Expert', song: 'All 10 Titles', chart: null }
+  ],
+  gimmick: [
+    { level: 1, song: 'Yeo rae a', chart: 'S13' },
+    { level: 2, song: 'Bad Apple', chart: 'S15' },
+    { level: 3, song: 'Love Scenario', chart: 'S17' },
+    { level: 4, song: 'Come to Me', chart: 'S17' },
+    { level: 5, song: 'Rock the house - SHORT CUT -', chart: 'S18' },
+    { level: 6, song: 'Miss S\' Story', chart: 'S19' },
+    { level: 7, song: 'Nakakapagpabagabag', chart: 'S19' },
+    { level: 8, song: 'Twist of Fate', chart: 'S19' },
+    { level: 9, song: 'Everybody Got 2 Know', chart: 'S19' },
+    { level: 10, song: '8 6', chart: 'S20' },
+    { level: 'Expert', song: 'All 10 Titles', chart: null }
+  ],
+  half: [
+    { level: 1, song: 'Trashy Innocence', chart: 'D16' },
+    { level: 2, song: 'Butterfly', chart: 'D17' },
+    { level: 3, song: 'Shub Niggurath', chart: 'D18' },
+    { level: 4, song: 'Super Fantasy', chart: 'D18' },
+    { level: 5, song: 'Phantom', chart: 'D19' },
+    { level: 6, song: 'Utsushiyo no Kaze', chart: 'D20' },
+    { level: 7, song: 'Witch Doctor #1', chart: 'D21' },
+    { level: 8, song: 'Bad Apple - FULL SONG -', chart: 'D22' },
+    { level: 9, song: 'Love is a Danger Zone 2 Try to B.P.M.', chart: 'D23' },
+    { level: 10, song: 'Imprinting', chart: 'D24' },
+    { level: 'Expert', song: 'All 10 Titles', chart: null }
+  ],
+  run: [
+    { level: 1, song: 'Final Audition', chart: 'D15' },
+    { level: 2, song: 'Super Fantasy', chart: 'S16' },
+    { level: 3, song: 'Pavane', chart: 'S17' },
+    { level: 4, song: 'Gothique Resonance', chart: 'S18' },
+    { level: 5, song: 'Napalm', chart: 'S19' },
+    { level: 6, song: 'Bee', chart: 'D20' },
+    { level: 7, song: 'Sarabande', chart: 'D21' },
+    { level: 8, song: 'Just Hold On (To All Fighters)', chart: 'D22' },
+    { level: 9, song: 'Final Audition Ep. 2-X', chart: 'S23', grade: 'S' },
+    { level: 10, song: 'Yog Sothoth', chart: 'D24' },
+    { level: 'Expert', song: 'All 10 Titles', chart: null }
+  ],
+  twistExpert: [
+    { level: 1, song: 'Street Showdown', chart: 'S15' },
+    { level: 2, song: 'Final Audition 3', chart: 'S16' },
+    { level: 3, song: 'U Got Me Rocking', chart: 'S17' },
+    { level: 4, song: 'Final Audition', chart: 'D18' },
+    { level: 5, song: 'Super Fantasy', chart: 'S19' },
+    { level: 6, song: 'Witch Doctor #1', chart: 'D20' },
+    { level: 7, song: 'LIADZ', chart: 'D21' },
+    { level: 8, song: 'LIADZ pt 2', chart: 'S22' },
+    { level: 9, song: 'LIADZ (Cranky)', chart: 'D23' },
+    { level: 10, song: 'Bee', chart: 'D24' },
+    { level: 'Expert', song: 'All 10 Titles', chart: null }
+  ]
+};
+
+const metaBadges = {
+  twistExpert: '[Twist] Expert',
+  specialist: 'Specialist'
+};
+
+module.exports = { songBadges, metaBadges };

--- a/Server/src/consts/titleRequirements.js
+++ b/Server/src/consts/titleRequirements.js
@@ -1,0 +1,29 @@
+const clearTitles = [
+  { title: 'Intermediate Lv. 1', diffs: '10-11', count: 25 },
+  { title: 'Intermediate Lv. 2', diffs: '10-11', count: 50 },
+  { title: 'Intermediate Lv. 3', diffs: '12-13', count: 25 },
+  { title: 'Intermediate Lv. 4', diffs: '12-13', count: 50 },
+  { title: 'Intermediate Lv. 5', diffs: '14-15', count: 25 },
+  { title: 'Intermediate Lv. 6', diffs: '14-15', count: 50 },
+  { title: 'Intermediate Lv. 7', diffs: '16-17', count: 25 },
+  { title: 'Intermediate Lv. 8', diffs: '16-17', count: 50 },
+  { title: 'Intermediate Lv. 9', diffs: '18-19', count: 25 },
+  { title: 'Intermediate Lv.10', diffs: '18-19', count: 50 },
+  { title: 'Advanced Lv. 1', diffs: '20', count: 25 },
+  { title: 'Advanced Lv. 2', diffs: '20', count: 50 },
+  { title: 'Advanced Lv. 3', diffs: '21', count: 25 },
+  { title: 'Advanced Lv. 4', diffs: '21', count: 50 },
+  { title: 'Advanced Lv. 5', diffs: '22', count: 20 },
+  { title: 'Advanced Lv. 6', diffs: '22', count: 40 },
+  { title: 'Advanced Lv. 7', diffs: '22', count: 60 },
+  { title: 'Advanced Lv. 8', diffs: '23', count: 20 },
+  { title: 'Advanced Lv. 9', diffs: '23', count: 35 },
+  { title: 'Advanced Lv.10', diffs: '23', count: 50 },
+  { title: 'Expert Lv. 1', diffs: '24', count: 30, requires: 'Advanced Lv. 10' },
+  { title: 'Expert Lv. 2', diffs: '25', count: 15, requires: 'Expert Lv. 1' },
+  { title: 'Expert Lv. 3', diffs: '26', count: 7, requires: 'Expert Lv. 2' },
+  { title: 'Expert Lv. 4', diffs: '27', count: 3, requires: 'Expert Lv. 3' },
+  { title: 'The Master', diffs: '28', count: 1, requires: 'Expert Lv. 4' }
+];
+
+module.exports = { clearTitles };

--- a/Server/src/services/achievement.service.js
+++ b/Server/src/services/achievement.service.js
@@ -1,0 +1,85 @@
+const prisma = require('../db');
+const { songBadges, metaBadges } = require('../consts/badges');
+const { clearTitles } = require('../consts/titleRequirements');
+
+const songs = require('../../Frontend/src/consts/songs.json');
+
+const gradeOrder = ['SSS','SS','S','Ap','A','Bp','B','Cp','C','Dp','D','F'];
+const gradeBetterOrEqual = (a, b) => {
+  if (!a) return false;
+  return gradeOrder.indexOf(a) <= gradeOrder.indexOf(b);
+};
+
+const diffNumber = (diff) => parseInt(diff.replace(/[^0-9]/g, ''), 10);
+
+const buildTitleMap = () => {
+  const map = {};
+  Object.entries(songs).forEach(([id, s]) => {
+    map[s.title] = id;
+  });
+  return map;
+};
+
+const titleToId = buildTitleMap();
+
+const checkBadges = (scores, currentBadges) => {
+  const badges = new Set(currentBadges || []);
+
+  Object.entries(songBadges).forEach(([category, reqs]) => {
+    let completed = 0;
+    reqs.forEach((req) => {
+      if (req.level === 'Expert') return;
+      const songId = titleToId[req.song];
+      if (!songId) return;
+      const sc = scores.find((s) => s.song_id === songId && s.diff === req.chart);
+      if (sc && gradeBetterOrEqual(sc.grade, req.grade || 'SS')) {
+        badges.add(`${category}_${req.level}`);
+        completed += 1;
+      }
+    });
+    if (completed >= 10 && category === 'twistExpert') {
+      badges.add(metaBadges.twistExpert);
+    }
+  });
+
+  const hasAllLevels = ['drill','gimmick','half','run','twistExpert'].every((c) => {
+    return badges.has(`${c}_10`);
+  });
+  if (hasAllLevels) badges.add(metaBadges.specialist);
+
+  return Array.from(badges);
+};
+
+const checkTitles = (scores, currentTitles) => {
+  const titles = new Set(currentTitles || []);
+
+  clearTitles.forEach((req) => {
+    const [minStr, maxStr] = req.diffs.split('-');
+    const min = parseInt(minStr, 10);
+    const max = maxStr ? parseInt(maxStr, 10) : min;
+    const songSet = new Set();
+    scores.forEach((sc) => {
+      const n = diffNumber(sc.diff);
+      if (n >= min && n <= max && sc.grade) {
+        songSet.add(sc.song_id);
+      }
+    });
+    if (songSet.size >= req.count && (!req.requires || titles.has(req.requires))) {
+      titles.add(req.title);
+    }
+  });
+
+  return Array.from(titles);
+};
+
+const updateUserAchievements = async (userId) => {
+  const user = await prisma.user.findUnique({ where: { id: userId }, include: { scores: true } });
+  if (!user) return;
+
+  const badges = checkBadges(user.scores, user.badges);
+  const titles = checkTitles(user.scores, user.titles);
+
+  await prisma.user.update({ where: { id: userId }, data: { badges, titles } });
+};
+
+module.exports = { updateUserAchievements };

--- a/Server/src/services/index.js
+++ b/Server/src/services/index.js
@@ -4,3 +4,4 @@ module.exports.tokenService = require('./token.service');
 module.exports.userService = require('./user.service');
 module.exports.scoresService = require('./scores.service');
 module.exports.leaderboardService = require('./leaderboard.service');
+module.exports.achievementService = require('./achievement.service');

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -1,4 +1,5 @@
 const prisma = require('../db');
+const { achievementService } = require('./index');
 
 const getScores = async (filter) => {
   const scores = await prisma.score.findMany({ where: { userId: filter.userId, mode: filter.mode } });
@@ -27,13 +28,18 @@ const createScore = async (scoreBody, mode, user) => {
     if (existing) {
       await prisma.score.delete({ where: { id: existing.id } });
     }
+    await achievementService.updateUserAchievements(user.id);
     return null;
   }
 
   if (existing) {
-    return prisma.score.update({ where: { id: existing.id }, data: { grade } });
+    const res = await prisma.score.update({ where: { id: existing.id }, data: { grade } });
+    await achievementService.updateUserAchievements(user.id);
+    return res;
   }
-  return prisma.score.create({ data: { song_id, diff, grade, userId: user.id, mode } });
+  const res = await prisma.score.create({ data: { song_id, diff, grade, userId: user.id, mode } });
+  await achievementService.updateUserAchievements(user.id);
+  return res;
 };
 
 const getLatestScores = async (limit = 10) =>

--- a/Server/src/services/user.service.js
+++ b/Server/src/services/user.service.js
@@ -13,7 +13,7 @@ const createUser = async (userBody) => {
     throw new ApiError(httpStatus.BAD_REQUEST, 'Username already taken');
   }
   const hashedPassword = await bcrypt.hash(userBody.password, 8);
-  const user = await prisma.user.create({ data: { ...userBody, password: hashedPassword, role: 'user' } });
+  const user = await prisma.user.create({ data: { ...userBody, password: hashedPassword, role: 'user', badges: [], titles: [] } });
   return user;
 };
 


### PR DESCRIPTION
## Summary
- track badges and titles on the server side
- update Prisma schema and create migration for achievements
- compute new achievements when posting a score
- display player's highest title and badges in profile page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68762e21c2288324998ae5624a4ab536