### PR TITLE
Fix missing achievement service

### DIFF
--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -1,5 +1,5 @@
 const prisma = require('../db');
-const { achievementService } = require('./index');
+const achievementService = require('./achievement.service');
 
 const getScores = async (filter) => {
   const scores = await prisma.score.findMany({ where: { userId: filter.userId, mode: filter.mode } });


### PR DESCRIPTION
## Summary
- fix circular dependency in scores service

## Testing
- `npm test --silent --prefix Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687632533c6c8324b1173e64c86dfb51