### PR TITLE
Implement automatic logout on session expiry

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -3,11 +3,27 @@ import Config from '../config'
 
 const client = axios.default.create({
     baseURL: Config.apiDefaultURL,
-    timeout: Config.apiTimeout, 
-    headers: {
-        'Authorization': `Bearer ${localStorage.getItem('token')}`
-    }
+    timeout: Config.apiTimeout,
 })
+
+client.interceptors.request.use(config => {
+    const token = localStorage.getItem('token')
+    if (token) {
+        config.headers['Authorization'] = `Bearer ${token}`
+    }
+    return config
+})
+
+client.interceptors.response.use(
+    response => response,
+    error => {
+        if (error.response && error.response.status === 401) {
+            localStorage.removeItem('token')
+            window.location.href = '/login'
+        }
+        return Promise.reject(error)
+    }
+)
 
 export class ApiClient {
 


### PR DESCRIPTION
## Summary
- intercept API responses and log out when receiving 401
- update request headers with fresh token every time

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763263df588324bf323979a2677511