### PR TITLE
Add expert badge support for all categories

### DIFF
--- a/Frontend/src/consts/badges.js
+++ b/Frontend/src/consts/badges.js
@@ -67,6 +67,10 @@ export const songBadges = {
 };
 
 export const metaBadges = {
+  drill: '[Drill] Expert',
+  gimmick: '[Gimmick] Expert',
+  half: '[Half] Expert',
+  run: '[Run] Expert',
   twistExpert: '[Twist] Expert',
   specialist: 'Specialist'
 };

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a PIU score tracker. The `Frontend/src/consts` folder now includes two additional files describing badge and title requirements:
 
-- **badges.js** – lists song specific badges such as *Drill*, *Gimmick*, *Half*, *Run* and *Twist Expert*. Clearing the listed chart with an SS grade awards the corresponding level. Final levels unlock meta badges `[Twist] Expert` and `Specialist`.
+- **badges.js** – lists song specific badges such as *Drill*, *Gimmick*, *Half*, *Run* and *Twist Expert*. Clearing the listed chart with an SS grade awards the corresponding level. Finishing all ten levels in any category now unlocks a meta badge like `[Drill] Expert` or `[Twist] Expert`. Collecting level 10 in every category grants the `Specialist` badge.
 - **titleRequirements.js** – defines titles earned for clearing a given number of songs within difficulty ranges (e.g. *Intermediate* and *Advanced* levels).
 
 These constants are meant for future logic awarding badges when users submit scores.

--- a/Server/src/consts/badges.js
+++ b/Server/src/consts/badges.js
@@ -67,6 +67,10 @@ const songBadges = {
 };
 
 const metaBadges = {
+  drill: '[Drill] Expert',
+  gimmick: '[Gimmick] Expert',
+  half: '[Half] Expert',
+  run: '[Run] Expert',
   twistExpert: '[Twist] Expert',
   specialist: 'Specialist'
 };

--- a/Server/src/services/achievement.service.js
+++ b/Server/src/services/achievement.service.js
@@ -37,12 +37,12 @@ const checkBadges = (scores, currentBadges) => {
         completed += 1;
       }
     });
-    if (completed >= 10 && category === 'twistExpert') {
-      badges.add(metaBadges.twistExpert);
+    if (completed >= 10 && metaBadges[category]) {
+      badges.add(metaBadges[category]);
     }
   });
 
-  const hasAllLevels = ['drill', 'gimmick', 'half', 'run', 'twistExpert'].every((c) => {
+  const hasAllLevels = Object.keys(songBadges).every((c) => {
     return badges.has(`${c}_10`);
   });
   if (hasAllLevels) badges.add(metaBadges.specialist);


### PR DESCRIPTION
## Summary
- add meta badges for Drill/Gimmick/Half/Run categories
- award meta badges dynamically for each category
- update README with new badges information

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763570fb848324b350f4a909e64521