### PR TITLE
Style sorting radio buttons horizontally

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -255,6 +255,7 @@ const Songs = ({ mode }) => {
         <FormControl>
           <FormLabel id="radio-buttons-group-label">Sort by</FormLabel>
           <SortOptions
+            row
             aria-labelledby="demo-radio-buttons-group-label"
             defaultValue="tier"
             value={sort}
@@ -595,8 +596,9 @@ const DiffSearch = styled.div`
 const SortOptions = styled(RadioGroup)`
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 10px;
+  justify-content: space-between;
   margin-bottom: 20px;
 `;
 


### PR DESCRIPTION
## Summary
- ensure the sorting radio buttons are displayed in one row
- tweak styling for the `SortOptions` radio group

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in `Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763a37eb1c8324bd27a738162132d9