### PR TITLE
Use icons for best passes

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -4,6 +4,20 @@ import Section from '../../Components/Layout/Section';
 import { ApiClient } from '../../API/httpService';
 import songs from '../../consts/songs.json';
 import compareGrades from '../../helpers/compareGrades';
+import grades from '../../Assets/Grades';
+import styled from 'styled-components';
+
+const MODE = 'item_single';
+
+const DiffBall = styled.span`
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+`;
+
+const GradeImg = styled.img`
+  height: 40px;
+`;
 
 const apiClient = new ApiClient();
 
@@ -45,7 +59,7 @@ const Profile = () => {
       <Section header="Best passes">
         <ul>
           {bestPasses.slice(0, 10).map((bp) => (
-            <li key={`${bp.songId}-${bp.diff}`}>{songs[bp.songId]?.title} - {bp.grade} ({bp.diff})</li>
+            <li key={`${bp.songId}-${bp.diff}`}>{songs[bp.songId]?.title} - <GradeImg src={grades[bp.grade]} alt={bp.grade}/> <DiffBall className={`${MODE} ${bp.diff}`} /></li>
           ))}
         </ul>
       </Section>


### PR DESCRIPTION
## Summary
- show grade icons and diff icons in profile best passes

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763af0cb7c83248bf7b44f545b2c01