### PR TITLE
Handle badge updates from new scores

### DIFF
--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -34,11 +34,11 @@ const createScore = async (scoreBody, mode, user) => {
 
   if (existing) {
     const res = await prisma.score.update({ where: { id: existing.id }, data: { grade } });
-    await achievementService.updateUserAchievements(user.id);
+    await achievementService.updateUserAchievements(user.id, res);
     return res;
   }
   const res = await prisma.score.create({ data: { song_id, diff, grade, userId: user.id, mode } });
-  await achievementService.updateUserAchievements(user.id);
+  await achievementService.updateUserAchievements(user.id, res);
   return res;
 };
 


### PR DESCRIPTION
## Summary
- add `updateBadgesWithScore` to incrementally award song badges
- update `updateUserAchievements` to accept a new score and check it
- call `updateUserAchievements` with the created/updated score

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763bc6e8d883249892d127ecbb8992