### PR TITLE
Hide diff filter on double/coop song pages

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -290,48 +290,50 @@ const Songs = ({ mode }) => {
           </AccordionSummary>
           <AccordionDetailsStyled>
             <Filters>
-              <DiffSearch>
-                With diffs:
-                <NumberInput
-                  label="P1"
-                  type="number"
-                  min="1"
-                  max={maxDiff}
-                  value={search?.p1Diff || ""}
-                  onChange={(e) =>
-                    setSearch(
-                      e.target.value
-                        ? { ...search, p1Diff: e.target.value }
-                        : undefined
-                    )
-                  }
-                />
-                <NumberInput
-                  label="P2"
-                  type="number"
-                  min="1"
-                  max={maxDiff}
-                  value={search?.p2Diff || ""}
-                  onChange={(e) =>
-                    setSearch(
-                      e.target.value
-                        ? { ...search, p2Diff: e.target.value }
-                        : undefined
-                    )
-                  }
-                />
-                <Button
-                  onClick={() =>
-                    setSearch({
-                      ...search,
-                      p1Diff: undefined,
-                      p2Diff: undefined,
-                    })
-                  }
-                >
-                  Clear
-                </Button>
-              </DiffSearch>
+              {mode === "item_single" && (
+                <DiffSearch>
+                  With diffs:
+                  <NumberInput
+                    label="P1"
+                    type="number"
+                    min="1"
+                    max={maxDiff}
+                    value={search?.p1Diff || ""}
+                    onChange={(e) =>
+                      setSearch(
+                        e.target.value
+                          ? { ...search, p1Diff: e.target.value }
+                          : undefined
+                      )
+                    }
+                  />
+                  <NumberInput
+                    label="P2"
+                    type="number"
+                    min="1"
+                    max={maxDiff}
+                    value={search?.p2Diff || ""}
+                    onChange={(e) =>
+                      setSearch(
+                        e.target.value
+                          ? { ...search, p2Diff: e.target.value }
+                          : undefined
+                      )
+                    }
+                  />
+                  <Button
+                    onClick={() =>
+                      setSearch({
+                        ...search,
+                        p1Diff: undefined,
+                        p2Diff: undefined,
+                      })
+                    }
+                  >
+                    Clear
+                  </Button>
+                </DiffSearch>
+              )}
               <div>
                 Tags:
                 <FormControlLabel


### PR DESCRIPTION
## Summary
- wrap "With diffs" filter in Songs page so it only appears for single charts

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in Server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687646954770832481d265fed356d5ff