### PR TITLE
Add achievement notifications

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -185,11 +185,18 @@ const Songs = ({ mode }) => {
   };
 
   const changeGrade = (value) => {
-    apiClient.postScores(mode, {
-      song_id: openChart.id,
-      diff: openChart.diff,
-      grade: value,
-    });
+    apiClient
+      .postScores(mode, {
+        song_id: openChart.id,
+        diff: openChart.diff,
+        grade: value,
+      })
+      .then((r) => {
+        const { newBadges = [], newTitles = [] } = r.data || {};
+        if (newBadges.length || newTitles.length) {
+          alert(`New achievements: ${[...newBadges, ...newTitles].join(', ')}`);
+        }
+      });
 
     if (details[mode][openChart.diff]) {
       if (details[mode][openChart.diff][openChart.id]) {

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ This repository contains a PIU score tracker. The `Frontend/src/consts` folder n
 - **titleRequirements.js** – defines titles earned for clearing a given number of songs within difficulty ranges (e.g. *Intermediate* and *Advanced* levels).
 
 These constants are meant for future logic awarding badges when users submit scores.
+
+Submitting a score now returns any newly earned badges or titles in the response. The front end displays an alert when new achievements are awarded.

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -14,8 +14,8 @@ const getScores = catchAsync(async (req, res) => {
 });
 
 const postScore = catchAsync(async (req, res) => {
-    const score = await scoresService.createScore(req.body, req.params.mode, req.user);
-    res.status(httpStatus.CREATED).send(score);
+    const result = await scoresService.createScore(req.body, req.params.mode, req.user);
+    res.status(httpStatus.CREATED).send(result);
 });
 
 const getLatestScores = catchAsync(async (req, res) => {

--- a/Server/src/services/achievement.service.js
+++ b/Server/src/services/achievement.service.js
@@ -105,7 +105,7 @@ const checkTitles = (scores, currentTitles) => {
 
 const updateUserAchievements = async (userId, score = null) => {
   const user = await prisma.user.findUnique({ where: { id: userId }, include: { scores: true } });
-  if (!user) return;
+  if (!user) return { newBadges: [], newTitles: [] };
 
   let badges;
   let titles;
@@ -119,7 +119,12 @@ const updateUserAchievements = async (userId, score = null) => {
     titles = checkTitles(user.scores, user.titles);
   }
 
+  const newBadges = badges.filter((b) => !user.badges.includes(b));
+  const newTitles = titles.filter((t) => !user.titles.includes(t));
+
   await prisma.user.update({ where: { id: userId }, data: { badges, titles } });
+
+  return { newBadges, newTitles };
 };
 
 module.exports = { updateUserAchievements };

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -28,17 +28,18 @@ const createScore = async (scoreBody, mode, user) => {
     if (existing) {
       await prisma.score.delete({ where: { id: existing.id } });
     }
-    return null;
+    const { newBadges, newTitles } = await achievementService.updateUserAchievements(user.id);
+    return { score: null, newBadges, newTitles };
   }
 
   if (existing) {
     const res = await prisma.score.update({ where: { id: existing.id }, data: { grade } });
-    await achievementService.updateUserAchievements(user.id, res);
-    return res;
+    const { newBadges, newTitles } = await achievementService.updateUserAchievements(user.id, res);
+    return { score: res, newBadges, newTitles };
   }
   const res = await prisma.score.create({ data: { song_id, diff, grade, userId: user.id, mode } });
-  await achievementService.updateUserAchievements(user.id, res);
-  return res;
+  const { newBadges, newTitles } = await achievementService.updateUserAchievements(user.id, res);
+  return { score: res, newBadges, newTitles };
 };
 
 const getLatestScores = async (limit = 10) =>


### PR DESCRIPTION
## Summary
- notify server when user gains badges or titles
- return new achievements from score API
- alert user on frontend when new achievements are awarded

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6876464960208324b53873882da9771b