### PR TITLE
Replace achievement alerts with site notifications

### DIFF
--- a/Frontend/src/Components/Layout/index.jsx
+++ b/Frontend/src/Components/Layout/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Outlet } from "react-router";
 import Navbar from "../Navigation";
+import NotificationProvider from "../Notification";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import { Box, GlobalStyles } from "@mui/material";
@@ -47,25 +48,27 @@ const Layout = () => {
   return (
     <ColorModeContext.Provider value={colorMode}>
       <ThemeProvider theme={mode === "light" ? themeLight : themeDark}>
-        <CssBaseline />
-        <GlobalStyles
-          styles={{
-            body: { backgroundColor: theme.background },
-          }}
-        />
-        <div>
-          <Navbar />
-          <Box
-            sx={{
-              padding: {
-                sx: "0px 0 0 0",
-                md: "50px 10%;",
-              },
+        <NotificationProvider>
+          <CssBaseline />
+          <GlobalStyles
+            styles={{
+              body: { backgroundColor: theme.background },
             }}
-          >
-            <Outlet />
-          </Box>
-        </div>
+          />
+          <div>
+            <Navbar />
+            <Box
+              sx={{
+                padding: {
+                  sx: "0px 0 0 0",
+                  md: "50px 10%;",
+                },
+              }}
+            >
+              <Outlet />
+            </Box>
+          </div>
+        </NotificationProvider>
       </ThemeProvider>
     </ColorModeContext.Provider>
   );

--- a/Frontend/src/Components/Notification/index.jsx
+++ b/Frontend/src/Components/Notification/index.jsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState } from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+const NotificationContext = createContext({
+  notify: () => {},
+});
+
+export const useNotification = () => useContext(NotificationContext);
+
+const NotificationProvider = ({ children }) => {
+  const [notification, setNotification] = useState(null);
+
+  const notify = (message, severity = 'info') => {
+    setNotification({ message, severity });
+  };
+
+  const handleClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setNotification(null);
+  };
+
+  return (
+    <NotificationContext.Provider value={{ notify }}>
+      {children}
+      <Snackbar
+        open={!!notification}
+        autoHideDuration={4000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {notification ? (
+          <Alert
+            onClose={handleClose}
+            severity={notification.severity}
+            sx={{ width: '100%' }}
+          >
+            {notification.message}
+          </Alert>
+        ) : null}
+      </Snackbar>
+    </NotificationContext.Provider>
+  );
+};
+
+export default NotificationProvider;

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -25,6 +25,7 @@ import songs from "../../consts/songs";
 import diffCounter from "../../consts/diffsCounter";
 import GradeSelect from "../../Components/GradeSelect";
 import compareGrades from "../../helpers/compareGrades";
+import { useNotification } from "../../Components/Notification";
 
 const apiClient = new ApiClient();
 
@@ -100,6 +101,7 @@ const filterItems = (a, details, mode, diff, hidden, hideScore, tags) => {
 };
 
 const Songs = ({ mode }) => {
+  const { notify } = useNotification();
   const [openChart, setOpenChart] = useState(false);
   const [search, setSearch] = useState();
   const [data, setData] = useState({});
@@ -194,7 +196,10 @@ const Songs = ({ mode }) => {
       .then((r) => {
         const { newBadges = [], newTitles = [] } = r.data || {};
         if (newBadges.length || newTitles.length) {
-          alert(`New achievements: ${[...newBadges, ...newTitles].join(', ')}`);
+          notify(
+            `New achievements: ${[...newBadges, ...newTitles].join(', ')}`,
+            'success'
+          );
         }
       });
 


### PR DESCRIPTION
## Summary
- add a generic NotificationProvider component using MUI Snackbar
- wrap Layout with NotificationProvider
- use notify() in Songs page when new achievements are earned

## Testing
- `npm test --silent --yes -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764a2f595c83249a6ef98d9104c602