### PR TITLE
Group songs by grade when sorting

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -125,7 +125,7 @@ const Songs = ({ mode }) => {
     ...Object.keys(diffCounter[mode]).map((d) => parseInt(d.replace("lv_", "")))
   );
 
-  let prevChart;
+  let prevCategory;
 
   const loadData = (songData) => {
     const newData = {};
@@ -542,15 +542,23 @@ const Songs = ({ mode }) => {
                       const adiff = chartData.diffs.find(
                         (a) => a.diff === diff && a.type === mode
                       )?.adiff;
-                      const divider = sort === "tier" && prevChart !== adiff;
-                      prevChart = adiff;
+                      const grade = chartData.grade;
+                      let divider = false;
+                      let dividerLabel = "";
+                      if (sort === "tier") {
+                        divider = prevCategory !== adiff;
+                        dividerLabel = adiff || "Not Specified";
+                        prevCategory = adiff;
+                      } else if (sort === "grade") {
+                        divider = prevCategory !== grade;
+                        dividerLabel = grade || "No Grade";
+                        prevCategory = grade;
+                      }
 
                       return (
                         <React.Fragment key={`${chart[0]}-${diff}`}>
                           {divider && (
-                            <DividerStyled>
-                              {adiff || "Not Specified"}
-                            </DividerStyled>
+                            <DividerStyled>{dividerLabel}</DividerStyled>
                           )}
                           <Thumbnail
                             data={chartData}


### PR DESCRIPTION
## Summary
- reset sorting group variable to use for grade tiers
- show divider headers per grade when sorting by grade

## Testing
- `npm install --prefix Frontend` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68764aa39b5c83248b4b3bb09bff62b5