### PR TITLE
Improve badge labels

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -17,6 +17,7 @@ import compareGrades from "../../helpers/compareGrades";
 import grades from "../../Assets/Grades";
 import styled from "styled-components";
 import getBestTitle from "../../helpers/getBestTitle";
+import { formatBadge } from "../../helpers/badgeUtils";
 
 const MODES = {
   SINGLE: "item_single",
@@ -126,7 +127,7 @@ const Profile = () => {
             {user.badges?.length > 0 && (
               <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1 }}>
                 {user.badges.map((b) => (
-                  <Chip key={b} label={b} size="small" />
+                  <Chip key={b} label={formatBadge(b)} size="small" />
                 ))}
               </Box>
             )}

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -26,6 +26,7 @@ import diffCounter from "../../consts/diffsCounter";
 import GradeSelect from "../../Components/GradeSelect";
 import compareGrades from "../../helpers/compareGrades";
 import { useNotification } from "../../Components/Notification";
+import { formatBadge } from "../../helpers/badgeUtils";
 
 const apiClient = new ApiClient();
 
@@ -196,8 +197,9 @@ const Songs = ({ mode }) => {
       .then((r) => {
         const { newBadges = [], newTitles = [] } = r.data || {};
         if (newBadges.length || newTitles.length) {
+          const badgeNames = newBadges.map((b) => formatBadge(b));
           notify(
-            `New achievements: ${[...newBadges, ...newTitles].join(', ')}`,
+            `New achievements: ${[...badgeNames, ...newTitles].join(', ')}`,
             'success'
           );
         }

--- a/Frontend/src/helpers/badgeUtils.js
+++ b/Frontend/src/helpers/badgeUtils.js
@@ -1,0 +1,12 @@
+export const formatBadge = (badge) => {
+  if (!badge) return '';
+  const parts = badge.split('_');
+  if (parts.length === 2 && !badge.startsWith('[')) {
+    const [category, level] = parts;
+    const labelCategory = category
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/^\w/, (c) => c.toUpperCase());
+    return `${labelCategory} Lvl ${level}`;
+  }
+  return badge;
+};


### PR DESCRIPTION
## Summary
- add a badge formatter helper
- show human-friendly badge names on profile page
- display formatted badge names in new achievement notifications

## Testing
- `npm test` (fails: jest not found)
- `npm test --silent` in Frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_68764c2e0d4483249c0cf5a238dc652b