### PR TITLE
Add 'More' dropdown for grade select

### DIFF
--- a/Frontend/src/Components/GradeSelect/index.jsx
+++ b/Frontend/src/Components/GradeSelect/index.jsx
@@ -4,29 +4,41 @@ import styled from 'styled-components'
 import grades from '../../Assets/Grades'
 
 const GradeSelect = ({ value, label, onChange }) => {
-    return <Select
-        value={value}
-        label={label}
-        onChange={onChange}
-    >
-        <MenuItem value={'SSS'}><Grade src={grades.SSS}/></MenuItem>
-        <MenuItem value={'SS'}><Grade src={grades.SS} /></MenuItem>
-        <MenuItem value={'S'}><Grade src={grades.S} /></MenuItem>
-        <MenuItem value={'Ap'}><Grade src={grades.Ap} /></MenuItem>
-        <MenuItem value={'Bp'}><Grade src={grades.Bp} /></MenuItem>
-        <MenuItem value={'Cp'}><Grade src={grades.Cp} /></MenuItem>
-        <MenuItem value={'Dp'}><Grade src={grades.Dp} /></MenuItem>
-        <MenuItem value={'A'}><Grade src={grades.A} /></MenuItem>
-        <MenuItem value={'B'}><Grade src={grades.B} /></MenuItem>
-        <MenuItem value={'C'}><Grade src={grades.C} /></MenuItem>
-        <MenuItem value={'D'}><Grade src={grades.D} /></MenuItem>
-        <MenuItem value={'F'}><Grade src={grades.F} /></MenuItem>
+    const mainGrades = ['SS', 'S', 'Ap', 'A']
+    const otherGrades = ['SSS', 'Bp', 'Cp', 'Dp', 'B', 'C', 'D', 'F']
 
-    </Select>
+    const mainValue = mainGrades.includes(value) ? value : ''
+    const otherValue = otherGrades.includes(value) ? value : ''
+
+    return <Wrapper>
+        <Select
+            value={mainValue}
+            label={label}
+            displayEmpty
+            onChange={onChange}
+            renderValue={(selected) => selected ? <Grade src={grades[selected]} /> : label}
+        >
+            {mainGrades.map(g => <MenuItem key={g} value={g}><Grade src={grades[g]} /></MenuItem>)}
+        </Select>
+        <Select
+            value={otherValue}
+            displayEmpty
+            onChange={onChange}
+            renderValue={(selected) => selected ? <Grade src={grades[selected]} /> : 'More'}
+        >
+            {otherGrades.map(g => <MenuItem key={g} value={g}><Grade src={grades[g]} /></MenuItem>)}
+        </Select>
+    </Wrapper>
 }
 
 export default GradeSelect
 
 const Grade = styled.img`
     height: 35px;
+`
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
 `


### PR DESCRIPTION
## Summary
- update `GradeSelect` component to split main grades from remaining grades
- style wrapper for dual selects

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764df4ac808324bb93636231eeea37