### PR TITLE
Update title calculation grade requirements

### DIFF
--- a/Server/src/services/achievement.service.js
+++ b/Server/src/services/achievement.service.js
@@ -10,6 +10,9 @@ const gradeBetterOrEqual = (a, b) => {
   return gradeOrder.indexOf(a) <= gradeOrder.indexOf(b);
 };
 
+// Grades that qualify when counting clears for title achievements
+const titleGrades = ['SSS', 'SS', 'S', 'Ap', 'Bp'];
+
 const diffNumber = (diff) => parseInt(diff.replace(/[^0-9]/g, ''), 10);
 
 const buildTitleMap = () => {
@@ -91,7 +94,7 @@ const checkTitles = (scores, currentTitles) => {
     const songSet = new Set();
     scores.forEach((sc) => {
       const n = diffNumber(sc.diff);
-      if (n >= min && n <= max && sc.grade) {
+      if (n >= min && n <= max && titleGrades.includes(sc.grade)) {
         songSet.add(sc.song_id);
       }
     });


### PR DESCRIPTION
## Summary
- refine achievement logic so only high grades count for title unlocks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764e133c2c8324bafc4625f499d368