### PR TITLE
Update grade selection UI

### DIFF
--- a/Frontend/src/Components/GradeSelect/index.jsx
+++ b/Frontend/src/Components/GradeSelect/index.jsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select } from '@mui/material'
+import { MenuItem, Select, Button } from '@mui/material'
 import React from 'react'
 import styled from 'styled-components'
 import grades from '../../Assets/Grades'
@@ -7,27 +7,30 @@ const GradeSelect = ({ value, label, onChange }) => {
     const mainGrades = ['SS', 'S', 'Ap', 'A']
     const otherGrades = ['SSS', 'Bp', 'Cp', 'Dp', 'B', 'C', 'D', 'F']
 
-    const mainValue = mainGrades.includes(value) ? value : ''
     const otherValue = otherGrades.includes(value) ? value : ''
 
+    const handleMoreChange = (e) => {
+        onChange(e.target.value)
+    }
+
     return <Wrapper>
-        <Select
-            value={mainValue}
-            label={label}
-            displayEmpty
-            onChange={onChange}
-            renderValue={(selected) => selected ? <Grade src={grades[selected]} /> : label}
-        >
-            {mainGrades.map(g => <MenuItem key={g} value={g}><Grade src={grades[g]} /></MenuItem>)}
-        </Select>
+        {label && <Label>{label}</Label>}
+        <MainButtons>
+            {mainGrades.map(g => (
+                <GradeButton key={g} $selected={value === g} onClick={() => onChange(g)}>
+                    <Grade src={grades[g]} />
+                </GradeButton>
+            ))}
+        </MainButtons>
         <Select
             value={otherValue}
             displayEmpty
-            onChange={onChange}
+            onChange={handleMoreChange}
             renderValue={(selected) => selected ? <Grade src={grades[selected]} /> : 'More'}
         >
             {otherGrades.map(g => <MenuItem key={g} value={g}><Grade src={grades[g]} /></MenuItem>)}
         </Select>
+        {value && <Button onClick={() => onChange('')}>Remove</Button>}
     </Wrapper>
 }
 
@@ -41,4 +44,19 @@ const Wrapper = styled.div`
     display: flex;
     align-items: center;
     gap: 8px;
+`
+
+const Label = styled.span`
+    margin-right: 4px;
+`
+
+const MainButtons = styled.div`
+    display: flex;
+    gap: 4px;
+`
+
+const GradeButton = styled(Button)`
+    min-width: 0;
+    padding: 0;
+    border: ${props => props.$selected ? '2px solid #1976d2' : 'none'};
 `

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -43,26 +43,14 @@ const SongDetails = ({ chart, changeGrade }) => {
       </div>
 
       {loggedIn && (
-        <>
-          <GradeSelect
-            label="Set Grade"
-            value={grade}
-            onChange={(e) => {
-              setGrade(e.target.value);
-              changeGrade(e.target.value);
-            }}
-          />
-          {grade && (
-            <Button
-              onClick={() => {
-                setGrade();
-                changeGrade();
-              }}
-            >
-              Remove
-            </Button>
-          )}
-        </>
+        <GradeSelect
+          label="Set Grade"
+          value={grade}
+          onChange={(g) => {
+            setGrade(g);
+            changeGrade(g);
+          }}
+        />
       )}
       
       {/* TODO: score upload */}

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -462,7 +462,7 @@ const Songs = ({ mode }) => {
                 />
                 <GradeSelect
                   value={hideScore}
-                  onChange={(e) => setHideScores(e.target.value)}
+                  onChange={(g) => setHideScores(g)}
                 />
                 <Accordion>
                   <AccordionSummary


### PR DESCRIPTION
## Summary
- switch grade selector to buttons with a dropdown for additional grades
- update song pages to use new GradeSelect API

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764f80cbc48324b22e773838766d4c