### PR TITLE
Add missing chart report feature

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -29,7 +29,7 @@ export class ApiClient {
 
     login = (params) => client.post('auth/login', params)
     register = (params) => client.post('auth/register', params)
-    
+
     getScores = (mode) => client.get(`scores/${mode}`)
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
     getLatestScores = (limit) => client.get('scores/latest', { params: { limit } })
@@ -37,6 +37,7 @@ export class ApiClient {
     getUsers = () => client.get('users')
     getUser = (id) => client.get(`users/${id}`)
     getLeaderboard = () => client.get('leaderboard')
+    reportMissing = (data) => client.post('missings', data)
 }
 
 export default client

--- a/Frontend/src/Components/Navigation/index.jsx
+++ b/Frontend/src/Components/Navigation/index.jsx
@@ -11,6 +11,11 @@ import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
 import MenuItem from "@mui/material/MenuItem";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
 import Logo from "../../Assets/logo.png";
 import Av from "../../Assets/anon.png";
 import styled from "styled-components";
@@ -21,6 +26,8 @@ import Brightness7Icon from "@mui/icons-material/Brightness7";
 import { ColorModeContext } from "../Layout";
 import { Link } from "react-router-dom";
 import { styled as styled2 } from "@mui/system";
+import { ApiClient } from "../../API/httpService";
+import { useNotification } from "../Notification";
 
 const pages = [
   "Single",
@@ -35,9 +42,14 @@ const settings = ["Profile", "Logout"];
 function NavBar() {
   const [anchorElNav, setAnchorElNav] = React.useState(null);
   const [anchorElUser, setAnchorElUser] = React.useState(null);
+  const [reportOpen, setReportOpen] = React.useState(false);
+  const [songName, setSongName] = React.useState('');
+  const [diff, setDiff] = React.useState('');
   const navigate = useNavigate();
   const theme = useTheme();
   const colorMode = React.useContext(ColorModeContext);
+  const { notify } = useNotification();
+  const apiClient = React.useMemo(() => new ApiClient(), []);
 
   const handleOpenNavMenu = (event) => {
     setAnchorElNav(event.currentTarget);
@@ -136,6 +148,12 @@ function NavBar() {
                   {page}
                 </Button>
               ))}
+            <Button
+              onClick={() => setReportOpen(true)}
+              sx={{ my: 2, color: "white", display: "block", ml: 2 }}
+            >
+              Report Missing Chart
+            </Button>
           </Box>
           {localStorage.getItem("token") ? (
             <Box sx={{ flexGrow: 0 }}>
@@ -182,6 +200,41 @@ function NavBar() {
         </Toolbar>
       </Container>
     </AppBar>
+    <Dialog open={reportOpen} onClose={() => setReportOpen(false)}>
+      <DialogTitle>Report Missing Chart</DialogTitle>
+      <DialogContent>
+        <TextField
+          margin="dense"
+          label="Song name"
+          fullWidth
+          value={songName}
+          onChange={(e) => setSongName(e.target.value)}
+        />
+        <TextField
+          margin="dense"
+          label="Diff"
+          fullWidth
+          value={diff}
+          onChange={(e) => setDiff(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setReportOpen(false)}>Cancel</Button>
+        <Button
+          onClick={() => {
+            apiClient
+              .reportMissing({ song_name: songName, diff })
+              .then(() => notify("Report submitted", "success"))
+              .catch(() => notify("Error submitting report", "error"));
+            setReportOpen(false);
+            setSongName('');
+            setDiff('');
+          }}
+        >
+          Submit
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 export default NavBar;

--- a/Server/prisma/migrations/20250715125927_add_missings_table/migration.sql
+++ b/Server/prisma/migrations/20250715125927_add_missings_table/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "Missing" (
+    "id" SERIAL NOT NULL,
+    "song_name" TEXT NOT NULL,
+    "diff" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Missing_pkey" PRIMARY KEY ("id")
+);

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -42,3 +42,10 @@ model Score {
   grade     String?
   mode      String
 }
+
+model Missing {
+  id        Int      @id @default(autoincrement())
+  song_name String
+  diff      String
+  createdAt DateTime @default(now())
+}

--- a/Server/src/controllers/index.js
+++ b/Server/src/controllers/index.js
@@ -2,3 +2,4 @@ module.exports.authController = require('./auth.controller');
 module.exports.userController = require('./user.controller');
 module.exports.scoresController = require('./scores.controller');
 module.exports.leaderboardController = require('./leaderboard.controller');
+module.exports.missingController = require('./missing.controller');

--- a/Server/src/controllers/missing.controller.js
+++ b/Server/src/controllers/missing.controller.js
@@ -1,0 +1,10 @@
+const httpStatus = require('http-status');
+const catchAsync = require('../utils/catchAsync');
+const { missingService } = require('../services');
+
+const createMissing = catchAsync(async (req, res) => {
+  const missing = await missingService.createMissing(req.body);
+  res.status(httpStatus.CREATED).send(missing);
+});
+
+module.exports = { createMissing };

--- a/Server/src/routes/v1/index.js
+++ b/Server/src/routes/v1/index.js
@@ -4,6 +4,7 @@ const userRoute = require('./user.route');
 const docsRoute = require('./docs.route');
 const scoresRoute = require('./scores.route');
 const leaderboardRoute = require('./leaderboard.route');
+const missingRoute = require('./missing.route');
 const config = require('../../config/config');
 
 const router = express.Router();
@@ -24,6 +25,10 @@ const defaultRoutes = [
   {
     path: '/leaderboard',
     route: leaderboardRoute,
+  },
+  {
+    path: '/missings',
+    route: missingRoute,
   },
 ];
 

--- a/Server/src/routes/v1/missing.route.js
+++ b/Server/src/routes/v1/missing.route.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const validate = require('../../middlewares/validate');
+const missingValidation = require('../../validations/missing.validation');
+const missingController = require('../../controllers/missing.controller');
+
+const router = express.Router();
+
+router.route('/')
+  .post(validate(missingValidation.createMissing), missingController.createMissing);
+
+module.exports = router;

--- a/Server/src/services/index.js
+++ b/Server/src/services/index.js
@@ -5,3 +5,4 @@ module.exports.userService = require('./user.service');
 module.exports.scoresService = require('./scores.service');
 module.exports.leaderboardService = require('./leaderboard.service');
 module.exports.achievementService = require('./achievement.service');
+module.exports.missingService = require('./missing.service');

--- a/Server/src/services/missing.service.js
+++ b/Server/src/services/missing.service.js
@@ -1,0 +1,8 @@
+const prisma = require('../db');
+
+const createMissing = async (data) => {
+  const { song_name, diff } = data;
+  return prisma.missing.create({ data: { song_name, diff } });
+};
+
+module.exports = { createMissing };

--- a/Server/src/validations/index.js
+++ b/Server/src/validations/index.js
@@ -1,3 +1,4 @@
 module.exports.authValidation = require('./auth.validation');
 module.exports.userValidation = require('./user.validation');
 module.exports.scoresValidation = require('./scores.validation');
+module.exports.missingValidation = require('./missing.validation');

--- a/Server/src/validations/missing.validation.js
+++ b/Server/src/validations/missing.validation.js
@@ -1,0 +1,10 @@
+const Joi = require('joi');
+
+const createMissing = {
+  body: Joi.object().keys({
+    song_name: Joi.string().required(),
+    diff: Joi.string().required(),
+  }),
+};
+
+module.exports = { createMissing };


### PR DESCRIPTION
## Summary
- add `Missing` table to Prisma schema and migration
- expose POST `/missings` route in backend
- add service, controller and validation for missing chart reports
- add report API to httpService
- add navbar button and popup dialog to report missing charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764ff85080832483eb66ca2118ec8a