### PR TITLE
Fix grade removal

### DIFF
--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -5,7 +5,7 @@ const createScore = {
     mode: Joi.string(),
   }),
   body: Joi.object().keys({
-    grade: Joi.string(),
+    grade: Joi.string().allow('', null),
     song_id: Joi.string().required(),
     diff: Joi.string().required(),
   }),


### PR DESCRIPTION
## Summary
- allow sending empty grade when deleting a score

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6876528c26b0832482ccd09f819b39ac