### PR TITLE
Implement local sorting persistence

### DIFF
--- a/Frontend/src/Pages/Leaderboard/index.jsx
+++ b/Frontend/src/Pages/Leaderboard/index.jsx
@@ -5,7 +5,9 @@ import { Box, FormControl, InputLabel, MenuItem, Select, Table, TableBody, Table
 const apiClient = new ApiClient();
 
 const Leaderboard = () => {
-  const [sort, setSort] = useState('singles');
+  const [sort, setSort] = useState(() =>
+    localStorage.getItem('leaderboardSort') || 'singles'
+  );
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -13,6 +15,10 @@ const Leaderboard = () => {
       setData(res.data);
     });
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('leaderboardSort', sort);
+  }, [sort]);
 
   const sortedData = [...data].sort((a, b) => b[sort] - a[sort]);
 

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -111,7 +111,9 @@ const Songs = ({ mode }) => {
     item_double: {},
     item_coop: {},
   });
-  const [sort, setSort] = useState("tier");
+  const [sort, setSort] = useState(() =>
+    localStorage.getItem("songSort") || "tier"
+  );
   const [hidden, setHidden] = useState({});
   const [tags, setTags] = useState({});
   const [hideScore, setHideScores] = useState("");
@@ -123,6 +125,10 @@ const Songs = ({ mode }) => {
   useEffect(() => {
     localStorage.setItem("hiddenDiffs", JSON.stringify(hiddenDiffs));
   }, [hiddenDiffs]);
+
+  useEffect(() => {
+    localStorage.setItem("songSort", sort);
+  }, [sort]);
 
   const maxDiff = Math.max(
     ...Object.keys(diffCounter[mode]).map((d) => parseInt(d.replace("lv_", "")))


### PR DESCRIPTION
## Summary
- save Songs page sorting to `songSort` in local storage
- save Leaderboard sorting to `leaderboardSort` in local storage

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876562cb5988324b991b73b5a16abb5