### PR TITLE
Restore score filter dropdown

### DIFF
--- a/Frontend/src/Components/GradeDropdown/index.jsx
+++ b/Frontend/src/Components/GradeDropdown/index.jsx
@@ -1,0 +1,31 @@
+import { MenuItem, Select } from '@mui/material'
+import React from 'react'
+import styled from 'styled-components'
+import grades from '../../Assets/Grades'
+
+const GradeDropdown = ({ value, label, onChange }) => {
+    return <Select
+        value={value}
+        label={label}
+        onChange={onChange}
+    >
+        <MenuItem value={'SSS'}><Grade src={grades.SSS}/></MenuItem>
+        <MenuItem value={'SS'}><Grade src={grades.SS} /></MenuItem>
+        <MenuItem value={'S'}><Grade src={grades.S} /></MenuItem>
+        <MenuItem value={'Ap'}><Grade src={grades.Ap} /></MenuItem>
+        <MenuItem value={'Bp'}><Grade src={grades.Bp} /></MenuItem>
+        <MenuItem value={'Cp'}><Grade src={grades.Cp} /></MenuItem>
+        <MenuItem value={'Dp'}><Grade src={grades.Dp} /></MenuItem>
+        <MenuItem value={'A'}><Grade src={grades.A} /></MenuItem>
+        <MenuItem value={'B'}><Grade src={grades.B} /></MenuItem>
+        <MenuItem value={'C'}><Grade src={grades.C} /></MenuItem>
+        <MenuItem value={'D'}><Grade src={grades.D} /></MenuItem>
+        <MenuItem value={'F'}><Grade src={grades.F} /></MenuItem>
+    </Select>
+}
+
+export default GradeDropdown
+
+const Grade = styled.img`
+    height: 35px;
+`

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -24,6 +24,7 @@ import SongDetails from "./SongDetails";
 import songs from "../../consts/songs";
 import diffCounter from "../../consts/diffsCounter";
 import GradeSelect from "../../Components/GradeSelect";
+import GradeDropdown from "../../Components/GradeDropdown";
 import compareGrades from "../../helpers/compareGrades";
 import { useNotification } from "../../Components/Notification";
 import { formatBadge } from "../../helpers/badgeUtils";
@@ -460,9 +461,9 @@ const Songs = ({ mode }) => {
                   }
                   label="Score better than"
                 />
-                <GradeSelect
+                <GradeDropdown
                   value={hideScore}
-                  onChange={(g) => setHideScores(g)}
+                  onChange={(e) => setHideScores(e.target.value)}
                 />
                 <Accordion>
                   <AccordionSummary


### PR DESCRIPTION
## Summary
- bring back GradeDropdown component for dropdown-based grade selection
- apply GradeDropdown to the "Score better than" filter on songs page

## Testing
- `npm install` *(fails: network restricted)*


------
https://chatgpt.com/codex/tasks/task_e_6876561307088324873e2cb749ed5b83