### PR TITLE
Fix profile page refresh routing

### DIFF
--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import {
-    createBrowserRouter,
+    createHashRouter,
     RouterProvider,
 } from "react-router-dom"
 import Layout from '../Components/Layout'
@@ -11,7 +11,7 @@ import Leaderboard from '../Pages/Leaderboard'
 import Login from '../Pages/Login'
 import Profile from '../Pages/Profile'
 
-const router = createBrowserRouter([
+const router = createHashRouter([
     {
         path: '/',
         element: <Layout />,


### PR DESCRIPTION
## Summary
- use `createHashRouter` instead of `createBrowserRouter`

Refreshing a profile page directly resulted in a blank screen since the static server did not handle client-side routing paths. By switching to a hash-based router, the application now works correctly when reloading profile pages.

## Testing
- `npm install` *(fails: registry.npmjs.org access blocked)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765772f8f48324b18debf8b3164a67