### PR TITLE
Add diff column in latest scores table

### DIFF
--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -24,6 +24,7 @@ const Scores = () => {
             <TableRow>
               <TableCell>User</TableCell>
               <TableCell>Song</TableCell>
+              <TableCell>Diff</TableCell>
               <TableCell>Grade</TableCell>
             </TableRow>
           </TableHead>
@@ -33,8 +34,8 @@ const Scores = () => {
                 <TableCell>
                   <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
                 </TableCell>
+                <TableCell>{songs[s.song_id]?.title || s.song_id}</TableCell>
                 <TableCell>
-                  {songs[s.song_id]?.title || s.song_id}{' '}
                   <DiffBall className={`${s.mode} ${s.diff}`} />
                 </TableCell>
                 <TableCell>


### PR DESCRIPTION
## Summary
- show difficulty as a separate column in Latest scores table

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687658f07f6c8324ba97353db3b604ab