### PR TITLE
Fix localeCompare error when sorting charts

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -111,9 +111,12 @@ const Songs = ({ mode }) => {
       case 'popularity':
         return parseInt(a[0]) - parseInt(b[0]);
       case 'tier':
-      default:
-        if (!adiff || !bdiff || adiff.adiff === '?' || bdiff.adiff === '?') return 0;
-        return adiff.adiff.localeCompare(bdiff.adiff);
+      default: {
+        const aTier = adiff?.adiff;
+        const bTier = bdiff?.adiff;
+        if (!aTier || !bTier || aTier === '?' || bTier === '?') return 0;
+        return String(aTier).localeCompare(String(bTier));
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- prevent `localeCompare` from accessing undefined values when sorting songs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765c6e78848324ab2bc042617d0749