### PR TITLE
Add badges info page with owned markers

### DIFF
--- a/Frontend/src/Pages/Titles/index.jsx
+++ b/Frontend/src/Pages/Titles/index.jsx
@@ -1,32 +1,108 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Section from '../../Components/Layout/Section';
 import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
 import { clearTitles } from '../../consts/titleRequirements';
+import { songBadges, metaBadges } from '../../consts/badges';
+import { ApiClient } from '../../API/httpService';
+import { formatBadge } from '../../helpers/badgeUtils';
 
 const Titles = () => {
+  const [ownedTitles, setOwnedTitles] = useState([]);
+  const [ownedBadges, setOwnedBadges] = useState([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      const api = new ApiClient();
+      api.getUser(payload.sub).then((r) => {
+        setOwnedTitles(r.data.titles || []);
+        setOwnedBadges(r.data.badges || []);
+      });
+    } catch (e) {
+      console.error('Failed to load user achievements', e);
+    }
+  }, []);
+
+  const badgeRows = [];
+  Object.entries(songBadges).forEach(([cat, reqs]) => {
+    reqs.forEach((req) => {
+      const key = req.level === 'Expert' ? metaBadges[cat] : `${cat}_${req.level}`;
+      badgeRows.push({
+        key: `${cat}-${req.level}`,
+        badge: key,
+        song: req.song,
+        diff: req.diff,
+        mode: req.mode,
+        grade: req.grade,
+      });
+    });
+  });
+  badgeRows.push({ key: 'specialist', badge: metaBadges.specialist });
+
   return (
-    <Section header="Titles info">
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Title</TableCell>
-            <TableCell>Diffs</TableCell>
-            <TableCell align="right">Count</TableCell>
-            <TableCell>Requires</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {clearTitles.map((t) => (
-            <TableRow key={t.title}>
-              <TableCell>{t.title}</TableCell>
-              <TableCell>{t.diffs}</TableCell>
-              <TableCell align="right">{t.count}</TableCell>
-              <TableCell>{t.requires || '-'}</TableCell>
+    <>
+      <Section header="Titles info">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Title</TableCell>
+              <TableCell>Diffs</TableCell>
+              <TableCell align="right">Count</TableCell>
+              <TableCell>Requires</TableCell>
+              <TableCell>Owned</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Section>
+          </TableHead>
+          <TableBody>
+            {clearTitles.map((t) => (
+              <TableRow key={t.title}>
+                <TableCell>{t.title}</TableCell>
+                <TableCell>{t.diffs}</TableCell>
+                <TableCell align="right">{t.count}</TableCell>
+                <TableCell>{t.requires || '-'}</TableCell>
+                <TableCell align="center">
+                  {ownedTitles.includes(t.title) && (
+                    <CheckIcon color="success" fontSize="small" />
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Section>
+      <Section header="Badges info">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Badge</TableCell>
+              <TableCell>Song</TableCell>
+              <TableCell>Diff</TableCell>
+              <TableCell>Mode</TableCell>
+              <TableCell>Grade</TableCell>
+              <TableCell>Owned</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {badgeRows.map((b) => (
+              <TableRow key={b.key}>
+                <TableCell>{formatBadge(b.badge)}</TableCell>
+                <TableCell>{b.song || '-'}</TableCell>
+                <TableCell>{b.diff || '-'}</TableCell>
+                <TableCell>{b.mode ? b.mode.replace('item_', '') : '-'}</TableCell>
+                <TableCell>{b.grade || (b.song ? 'SS' : '-')}</TableCell>
+                <TableCell align="center">
+                  {ownedBadges.includes(b.badge) && (
+                    <CheckIcon color="success" fontSize="small" />
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Section>
+    </>
   );
 };
 

--- a/Frontend/src/consts/badges.js
+++ b/Frontend/src/consts/badges.js
@@ -1,4 +1,4 @@
-const songBadges = {
+export const songBadges = {
   drill: [
     { level: 1, song: "Vook", songId: 340, mode: "item_single", diff: "lv_15" },
     {
@@ -343,9 +343,9 @@ const songBadges = {
   ],
 };
 
-const metaBadges = {
+export const metaBadges = {
   twist: "[Twist] Expert",
   specialist: "Specialist",
 };
 
-module.exports = { songBadges, metaBadges };
+export { songBadges, metaBadges };


### PR DESCRIPTION
## Summary
- switch badges constants to ES module exports
- fetch user data and show owned checkmarks on titles
- display badge requirements in Titles page

## Testing
- `npm test --prefix Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687665a3c480832485e6b283054dcdac