### PR TITLE
Display ADiff in song details

### DIFF
--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -95,7 +95,7 @@ const SongDetails = ({ chart, changeGrade }) => {
         </PackList>
         <Divider sx={{ my: 2 }} />
         <Typography variant="subtitle2" gutterBottom>
-          Difficulty rating
+          Difficulty rating {mainDiff.adiff && `(${mainDiff.adiff})`}
         </Typography>
         <RateButtons>
           <Button color="error" size="small" onClick={() => rateChart(1)}>


### PR DESCRIPTION
## Summary
- show each chart's `adiff` value next to the Difficulty rating label

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766816b0188324a78711db020a7a3c