### PR TITLE
Add ability to favorite charts

### DIFF
--- a/Frontend/src/Components/Thumbnail/index.jsx
+++ b/Frontend/src/Components/Thumbnail/index.jsx
@@ -3,6 +3,8 @@ import styled from 'styled-components'
 import ChatIcon from '@mui/icons-material/Chat';
 import { Divider, Icon } from '@mui/material';
 import { styled as styledMui } from '@mui/system';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { useNavigate } from 'react-router';
 import grades from '../../Assets/Grades';
 
@@ -18,7 +20,7 @@ const TAG_COLORS = {
 }
 
 
-const Thumbnail = ({data, onClick}) => {
+const Thumbnail = ({data, onClick, onToggleFavorite}) => {
     const navigate = useNavigate()
     const diffData = data.diffs?.find(
         (d) => d.diff === data.diff && d.type === data.mode
@@ -32,16 +34,21 @@ const Thumbnail = ({data, onClick}) => {
     }
 
     return (
-        <Container
-            onClick={onClick}
-        >
+        <Container onClick={onClick}>
             <Image>
                 {tcolors.length > 0 && <TagIndicator style={tagStyle} />}
                 <MainImg src={data.img} />
                 {data.grade && <Score src={grades[data.grade]}/>}
                 <Short>{data.bpm}</Short>
+                <FavButton
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleFavorite();
+                    }}
+                >
+                    {data.fav ? <StarIcon /> : <StarBorderIcon />}
+                </FavButton>
             </Image>
-
         </Container>
     )
 }
@@ -105,4 +112,13 @@ const TagIndicator = styled.div`
     top: 2px;
     left: 2px;
     z-index: 2;
+`
+
+const FavButton = styled.div`
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    z-index: 2;
+    color: gold;
+    display: flex;
 `

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -1,12 +1,14 @@
 import React, { useMemo, useState, useEffect } from "react";
-import { Box, Typography, Divider, Button } from "@mui/material";
+import { Box, Typography, Divider, Button, IconButton } from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
 
 import styled from "styled-components";
 import GradeSelect from "../../Components/GradeSelect";
 import packs from "../../consts/packs";
 import { ApiClient } from "../../API/httpService";
 
-const SongDetails = ({ chart, changeGrade }) => {
+const SongDetails = ({ chart, changeGrade, toggleFavorite }) => {
   const [grade, setGrade] = useState(chart.grade || "");
   const loggedIn = Boolean(localStorage.getItem("token"));
   const [ratings, setRatings] = useState({ harder: 0, ok: 0, easier: 0 });
@@ -47,6 +49,9 @@ const SongDetails = ({ chart, changeGrade }) => {
       <CoverWrapper>
         <DiffBallMain className={`${chart.mode} ${chart.diff}`} />
         <Cover src={chart.img} alt={chart.title} />
+        <FavoriteButton onClick={() => toggleFavorite(chart)}>
+          {chart.fav ? <StarIcon /> : <StarBorderIcon />}
+        </FavoriteButton>
       </CoverWrapper>
       <Content>
         <Typography variant="h5" gutterBottom>
@@ -202,6 +207,13 @@ const DiffBallMain = styled.span`
   left: 20px;
   top: 20px;
 
+`;
+
+const FavoriteButton = styled(IconButton)`
+  position: absolute !important;
+  top: 8px;
+  right: 8px;
+  color: gold;
 `;
 
 const DiffBall = styled.span`

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -126,9 +126,18 @@ const Songs = ({ mode }) => {
     return stored ? JSON.parse(stored) : { item_single: {}, item_double: {} };
   });
 
+  const [favorites, setFavorites] = useState(() => {
+    const stored = localStorage.getItem("favorites");
+    return stored ? JSON.parse(stored) : {};
+  });
+
   useEffect(() => {
     localStorage.setItem("hiddenDiffs", JSON.stringify(hiddenDiffs));
   }, [hiddenDiffs]);
+
+  useEffect(() => {
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+  }, [favorites]);
 
   useEffect(() => {
     localStorage.setItem("songSort", sort);
@@ -226,6 +235,25 @@ const Songs = ({ mode }) => {
     }
   };
 
+  const toggleFavorite = (chart) => {
+    const key = `${chart.id}-${chart.diff}-${chart.mode}`;
+    setFavorites((prev) => {
+      const updated = { ...prev };
+      if (updated[key]) {
+        delete updated[key];
+      } else {
+        updated[key] = true;
+      }
+      return updated;
+    });
+    if (openChart &&
+        openChart.id === chart.id &&
+        openChart.diff === chart.diff &&
+        openChart.mode === chart.mode) {
+      setOpenChart({ ...openChart, fav: !favorites[key] });
+    }
+  };
+
   const shouldDisplayDiff = (diff) => {
     const prefix1 = search?.p1Diff > 9 ? "lv_" : "lv_0";
     const prefix2 = search?.p2Diff > 9 ? "lv_" : "lv_0";
@@ -262,7 +290,11 @@ const Songs = ({ mode }) => {
         aria-describedby="modal-modal-description"
       >
         <StyledBox>
-          <SongDetails chart={openChart} changeGrade={changeGrade} />
+          <SongDetails
+            chart={openChart}
+            changeGrade={changeGrade}
+            toggleFavorite={toggleFavorite}
+          />
         </StyledBox>
       </Modal>
 
@@ -546,6 +578,7 @@ const Songs = ({ mode }) => {
                         ...(details[mode][diff]
                           ? details[mode][diff][chart[0]]
                           : {}),
+                        fav: favorites[`${chart[0]}-${diff}-${mode}`],
                       };
 
                       const adiff = chartData.diffs.find(
@@ -572,6 +605,7 @@ const Songs = ({ mode }) => {
                           <Thumbnail
                             data={chartData}
                             onClick={() => openPopup(chartData)}
+                            onToggleFavorite={() => toggleFavorite(chartData)}
                           />
                         </React.Fragment>
                       );


### PR DESCRIPTION
## Summary
- allow toggling favourites on songs
- display favourite star on thumbnails and details

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in Server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766fbdaeb48324b3b64f319dd83e15