### PR TITLE
Fix profile scores retrieval and add leaderboard links

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -30,11 +30,11 @@ export class ApiClient {
     login = (params) => client.post('auth/login', params)
     register = (params) => client.post('auth/register', params)
 
-    getScores = (mode) => client.get(`scores/${mode}`)
+    getScores = (mode, userId) => client.get(`scores/${mode}`, { params: userId ? { userId } : {} })
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
     getLatestScores = (limit) => client.get('scores/latest', { params: { limit } })
 
-    getGoals = (mode) => client.get(`goals/${mode}`)
+    getGoals = (mode, userId) => client.get(`goals/${mode}`, { params: userId ? { userId } : {} })
     postGoal = (mode, data) => client.post(`goals/${mode}`, data)
 
     getUsers = () => client.get('users')

--- a/Frontend/src/Pages/Leaderboard/index.jsx
+++ b/Frontend/src/Pages/Leaderboard/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ApiClient } from '../../API/httpService';
 import { Box, FormControl, InputLabel, MenuItem, Select, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import { Link } from 'react-router-dom';
 
 const apiClient = new ApiClient();
 
@@ -42,7 +43,9 @@ const Leaderboard = () => {
         <TableBody>
           {sortedData.map((row) => (
             <TableRow key={row.id}>
-              <TableCell>{row.username}</TableCell>
+              <TableCell>
+                <Link to={`/profile/${row.id}`}>{row.username}</Link>
+              </TableCell>
               <TableCell align="right">{row.singles ? `LV ${row.singles}` : '-'}</TableCell>
               <TableCell align="right">{row.doubles ? `LV ${row.doubles}` : '-'}</TableCell>
             </TableRow>

--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -90,10 +90,10 @@ const Profile = () => {
       setUser(r.data);
       setBestTitle(getBestTitle(r.data.titles));
     });
-    apiClient.getScores(MODES.SINGLE).then((r) => setSingleScores(r.data));
-    apiClient.getScores(MODES.DOUBLE).then((r) => setDoubleScores(r.data));
-    apiClient.getGoals(MODES.SINGLE).then((r) => setSingleGoals(r.data));
-    apiClient.getGoals(MODES.DOUBLE).then((r) => setDoubleGoals(r.data));
+    apiClient.getScores(MODES.SINGLE, id).then((r) => setSingleScores(r.data));
+    apiClient.getScores(MODES.DOUBLE, id).then((r) => setDoubleScores(r.data));
+    apiClient.getGoals(MODES.SINGLE, id).then((r) => setSingleGoals(r.data));
+    apiClient.getGoals(MODES.DOUBLE, id).then((r) => setDoubleGoals(r.data));
   }, [id]);
 
   const getAdiff = (songId, diff, mode) => {

--- a/Server/src/controllers/goals.controller.js
+++ b/Server/src/controllers/goals.controller.js
@@ -4,7 +4,8 @@ const { goalsService } = require('../services');
 
 const getGoals = catchAsync(async (req, res) => {
   const mode = req.params.mode;
-  const goals = await goalsService.getGoals(mode, req.user.id);
+  const userId = req.query.userId || req.user.id;
+  const goals = await goalsService.getGoals(mode, userId);
   res.send(goals);
 });
 

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -6,10 +6,10 @@ const { scoresService } = require('../services');
 
 const getScores = catchAsync(async (req, res) => {
     const mode = req.params.mode
-    const user = {userId: req.user.id}
-    const filter = pick(user, ['userId']);
+    const userId = req.query.userId || req.user.id
+    const filter = { userId }
     const options = pick(req.query, ['sortBy', 'limit', 'page']);
-    const result = await scoresService.getScores({...filter, mode}, options);
+    const result = await scoresService.getScores({ ...filter, mode }, options);
     res.send(result);
 });
 

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -14,6 +14,7 @@ const createScore = {
 const getScores = {
   query: Joi.object().keys({
     mode: Joi.string(),
+    userId: Joi.string(),
   }),
 };
 


### PR DESCRIPTION
## Summary
- link usernames on leaderboard to profile pages
- support fetching scores/goals for any user
- show correct user data in profile page

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in `Server` *(fails: jest not found)*
- `npm run lint` in `Server` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6878afe14ad88324ba3616d9bf2ab1bb