### PR TITLE
Fix pass counts in profile stats

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -136,12 +136,20 @@ const Profile = () => {
       .map(([diff, vals]) => {
         const stats = { A: 0, S: 0, SS: 0, SSS: 0, total: 0 };
         Object.values(vals).forEach(({ grade }) => {
-          stats.total += 1;
           if (!grade) return;
-          if (grade === "SSS") stats.SSS += 1;
-          else if (grade === "SS") stats.SS += 1;
-          else if (grade === "S") stats.S += 1;
-          else if (grade.startsWith("A")) stats.A += 1;
+          if (grade === "SSS") {
+            stats.SSS += 1;
+            stats.total += 1;
+          } else if (grade === "SS") {
+            stats.SS += 1;
+            stats.total += 1;
+          } else if (grade === "S") {
+            stats.S += 1;
+            stats.total += 1;
+          } else if (grade.startsWith("A")) {
+            stats.A += 1;
+            stats.total += 1;
+          }
         });
         return { diff, ...stats };
       })


### PR DESCRIPTION
## Summary
- count only passing grades when generating pass stats

## Testing
- `npm install --silent` *(fails: unable to connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6878b1bd8cb48324a77804068bba8f75