### PR TITLE
Add leaderboard section styling

### DIFF
--- a/Frontend/src/Pages/Leaderboard/index.jsx
+++ b/Frontend/src/Pages/Leaderboard/index.jsx
@@ -1,9 +1,34 @@
 import React, { useEffect, useState } from 'react';
 import { ApiClient } from '../../API/httpService';
-import { Box, FormControl, InputLabel, MenuItem, Select, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import Section from '../../Components/Layout/Section';
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 
 const apiClient = new ApiClient();
+
+const UserLink = styled(Link)`
+  color: inherit;
+  text-decoration: underline;
+  font-weight: bold;
+`;
+
+const Wrapper = styled(Box)`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
 
 const Leaderboard = () => {
   const [sort, setSort] = useState(() =>
@@ -24,35 +49,46 @@ const Leaderboard = () => {
   const sortedData = [...data].sort((a, b) => b[sort] - a[sort]);
 
   return (
-    <Box sx={{ p: 2 }}>
-      <FormControl sx={{ mb: 2, minWidth: 120 }} size="small">
-        <InputLabel id="sort-select-label">Sort By</InputLabel>
-        <Select labelId="sort-select-label" value={sort} label="Sort By" onChange={(e) => setSort(e.target.value)}>
-          <MenuItem value={'singles'}>Singles</MenuItem>
-          <MenuItem value={'doubles'}>Doubles</MenuItem>
-        </Select>
-      </FormControl>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>User</TableCell>
-            <TableCell align="right">Singles</TableCell>
-            <TableCell align="right">Doubles</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {sortedData.map((row) => (
-            <TableRow key={row.id}>
-              <TableCell>
-                <Link to={`/profile/${row.id}`}>{row.username}</Link>
-              </TableCell>
-              <TableCell align="right">{row.singles ? `LV ${row.singles}` : '-'}</TableCell>
-              <TableCell align="right">{row.doubles ? `LV ${row.doubles}` : '-'}</TableCell>
+    <Section header="Leaderboard">
+      <Wrapper>
+        <FormControl sx={{ mb: 2, minWidth: 120 }} size="small">
+          <InputLabel id="sort-select-label">Sort By</InputLabel>
+          <Select
+            labelId="sort-select-label"
+            value={sort}
+            label="Sort By"
+            onChange={(e) => setSort(e.target.value)}
+          >
+            <MenuItem value={'singles'}>Singles</MenuItem>
+            <MenuItem value={'doubles'}>Doubles</MenuItem>
+          </Select>
+        </FormControl>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>User</TableCell>
+              <TableCell align="right">Singles</TableCell>
+              <TableCell align="right">Doubles</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Box>
+          </TableHead>
+          <TableBody>
+            {sortedData.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>
+                  <UserLink to={`/profile/${row.id}`}>{row.username}</UserLink>
+                </TableCell>
+                <TableCell align="right">
+                  {row.singles ? `LV ${row.singles}` : '-'}
+                </TableCell>
+                <TableCell align="right">
+                  {row.doubles ? `LV ${row.doubles}` : '-'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Wrapper>
+    </Section>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap leaderboard page in `Section`
- apply small table and style user links

## Testing
- `npm test` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_6878b1daafa88324a3018b46e7b367f3