### PR TITLE
Add paginated all scores view

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -33,6 +33,7 @@ export class ApiClient {
     getScores = (mode, userId) => client.get(`scores/${mode}`, { params: userId ? { userId } : {} })
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
     getLatestScores = (limit) => client.get('scores/latest', { params: { limit } })
+    getAllScores = (page, limit) => client.get('scores/all', { params: { page, limit } })
 
     getGoals = (mode, userId) => client.get(`goals/${mode}`, { params: userId ? { userId } : {} })
     postGoal = (mode, data) => client.post(`goals/${mode}`, data)

--- a/Frontend/src/Pages/Scores/All.jsx
+++ b/Frontend/src/Pages/Scores/All.jsx
@@ -5,20 +5,33 @@ import songs from '../../consts/songs.json';
 import styled from 'styled-components';
 import grades from '../../Assets/Grades';
 import { Link } from 'react-router-dom';
-import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TablePagination,
+} from '@mui/material';
 
 const apiClient = new ApiClient();
 
-const Scores = () => {
-  const [latest, setLatest] = useState([]);
+const AllScores = () => {
+  const [scores, setScores] = useState([]);
+  const [page, setPage] = useState(0);
+  const [total, setTotal] = useState(0);
+  const rowsPerPage = 30;
 
   useEffect(() => {
-    apiClient.getLatestScores().then((res) => setLatest(res.data)).catch(() => {});
-  }, []);
+    apiClient.getAllScores(page + 1, rowsPerPage).then((res) => {
+      setScores(res.data.results);
+      setTotal(res.data.totalResults);
+    });
+  }, [page]);
 
   return (
     <>
-      <Section header="Latest scores">
+      <Section header="All scores">
         <Table size="small">
           <TableHead>
             <TableRow>
@@ -30,7 +43,7 @@ const Scores = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {latest.map((s) => (
+            {scores.map((s) => (
               <TableRow key={s.id}>
                 <TableCell>
                   <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
@@ -40,27 +53,27 @@ const Scores = () => {
                   <DiffBall className={`${s.mode} ${s.diff}`} />
                 </TableCell>
                 <TableCell>
-                  {s.grade ? (
-                    <GradeIcon src={grades[s.grade]} alt={s.grade} />
-                  ) : (
-                    '-'
-                  )}
+                  {s.grade ? <GradeIcon src={grades[s.grade]} alt={s.grade} /> : '-'}
                 </TableCell>
                 <TableCell>{new Date(s.createdAt).toLocaleDateString()}</TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
-        <p>
-          <Link to="/ScoresAll">See all scores</Link>
-        </p>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(e, p) => setPage(p)}
+          rowsPerPage={rowsPerPage}
+          rowsPerPageOptions={[rowsPerPage]}
+        />
       </Section>
     </>
   );
 };
 
-export default Scores;
-
+export default AllScores;
 
 const GradeIcon = styled.img`
   height: 20px;

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -6,6 +6,7 @@ import {
 import Layout from '../Components/Layout'
 import Songs from '../Pages/Songs'
 import Scores from '../Pages/Scores'
+import AllScores from '../Pages/Scores/All'
 import Leaderboard from '../Pages/Leaderboard'
 import Titles from '../Pages/Titles'
 // import { useDispatch, useSelector } from 'react-redux'
@@ -36,6 +37,10 @@ const router = createHashRouter([
             {
                 path: 'Scores',
                 element: <Scores />
+            },
+            {
+                path: 'ScoresAll',
+                element: <AllScores />
             },
             {
                 path: 'Leaderboard',

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -24,8 +24,16 @@ const getLatestScores = catchAsync(async (req, res) => {
     res.send(result);
 });
 
+const getAllScores = catchAsync(async (req, res) => {
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = parseInt(req.query.limit, 10) || 30;
+    const result = await scoresService.getAllScores(page, limit);
+    res.send(result);
+});
+
 module.exports = {
     getScores,
     postScore,
     getLatestScores,
+    getAllScores,
 };

--- a/Server/src/routes/v1/scores.route.js
+++ b/Server/src/routes/v1/scores.route.js
@@ -11,6 +11,10 @@ router
   .get(validate(scoresValidation.getLatestScores), scoresController.getLatestScores);
 
 router
+  .route('/all')
+  .get(validate(scoresValidation.getAllScores), scoresController.getAllScores);
+
+router
   .route('/:mode')
   .post(auth('postScores'), validate(scoresValidation.createScore), scoresController.postScore)
   .get(auth('getScores'), validate(scoresValidation.getScores), scoresController.getScores);

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -53,8 +53,26 @@ const getLatestScores = async (limit = 10) =>
     },
   });
 
+const getAllScores = async (page = 1, limit = 30) => {
+  const skip = (page - 1) * limit;
+  const results = await prisma.score.findMany({
+    skip,
+    take: limit,
+    orderBy: { id: 'desc' },
+    include: {
+      user: {
+        select: { username: true },
+      },
+    },
+  });
+  const totalResults = await prisma.score.count();
+  const totalPages = Math.ceil(totalResults / limit);
+  return { results, page, limit, totalPages, totalResults };
+};
+
 module.exports = {
   getScores,
   createScore,
   getLatestScores,
+  getAllScores,
 };

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -24,8 +24,16 @@ const getLatestScores = {
   }),
 };
 
+const getAllScores = {
+  query: Joi.object().keys({
+    page: Joi.number().integer(),
+    limit: Joi.number().integer(),
+  }),
+};
+
 module.exports = {
   createScore,
   getScores,
   getLatestScores,
+  getAllScores,
 };


### PR DESCRIPTION
## Summary
- add route, controller, and service to fetch all scores with pagination
- validate params for new all-scores API
- expose new `getAllScores` API to the frontend
- create `AllScores` page with pagination
- link from latest scores to new page and register route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b1fd74488324b7301cc049ebe6fb