### PR TITLE
Show recent players

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -33,6 +33,7 @@ export class ApiClient {
     getScores = (mode, userId) => client.get(`scores/${mode}`, { params: userId ? { userId } : {} })
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
     getLatestScores = (limit) => client.get('scores/latest', { params: { limit } })
+    getLatestPlayers = (limit) => client.get('scores/latestPlayers', { params: { limit } })
 
     getGoals = (mode, userId) => client.get(`goals/${mode}`, { params: userId ? { userId } : {} })
     postGoal = (mode, data) => client.post(`goals/${mode}`, data)

--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -11,9 +11,13 @@ const apiClient = new ApiClient();
 
 const Scores = () => {
   const [latest, setLatest] = useState([]);
+  const [latestPlayers, setLatestPlayers] = useState([]);
 
   useEffect(() => {
     apiClient.getLatestScores().then((res) => setLatest(res.data)).catch(() => {});
+    apiClient.getLatestPlayers()
+      .then((res) => setLatestPlayers(res.data))
+      .catch(() => {});
   }, []);
 
   return (
@@ -47,6 +51,26 @@ const Scores = () => {
                   )}
                 </TableCell>
                 <TableCell>{new Date(s.createdAt).toLocaleDateString()}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Section>
+      <Section header="Latest players">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>User</TableCell>
+              <TableCell>Date</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {latestPlayers.map((p) => (
+              <TableRow key={p.userId}>
+                <TableCell>
+                  <UserLink to={`/profile/${p.userId}`}>{p.user?.username}</UserLink>
+                </TableCell>
+                <TableCell>{new Date(p.createdAt).toLocaleDateString()}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -24,8 +24,15 @@ const getLatestScores = catchAsync(async (req, res) => {
     res.send(result);
 });
 
+const getLatestPlayers = catchAsync(async (req, res) => {
+    const limit = parseInt(req.query.limit, 10) || 10;
+    const result = await scoresService.getLatestPlayers(limit);
+    res.send(result);
+});
+
 module.exports = {
     getScores,
     postScore,
     getLatestScores,
+    getLatestPlayers,
 };

--- a/Server/src/routes/v1/scores.route.js
+++ b/Server/src/routes/v1/scores.route.js
@@ -11,6 +11,10 @@ router
   .get(validate(scoresValidation.getLatestScores), scoresController.getLatestScores);
 
 router
+  .route('/latestPlayers')
+  .get(validate(scoresValidation.getLatestPlayers), scoresController.getLatestPlayers);
+
+router
   .route('/:mode')
   .post(auth('postScores'), validate(scoresValidation.createScore), scoresController.postScore)
   .get(auth('getScores'), validate(scoresValidation.getScores), scoresController.getScores);

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -53,8 +53,21 @@ const getLatestScores = async (limit = 10) =>
     },
   });
 
+const getLatestPlayers = async (limit = 10) =>
+  prisma.score.findMany({
+    distinct: ['userId'],
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    include: {
+      user: {
+        select: { username: true },
+      },
+    },
+  });
+
 module.exports = {
   getScores,
   createScore,
   getLatestScores,
+  getLatestPlayers,
 };

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -24,8 +24,15 @@ const getLatestScores = {
   }),
 };
 
+const getLatestPlayers = {
+  query: Joi.object().keys({
+    limit: Joi.number(),
+  }),
+};
+
 module.exports = {
   createScore,
   getScores,
   getLatestScores,
+  getLatestPlayers,
 };


### PR DESCRIPTION
## Summary
- expose distinct player list based on latest score activity
- validate new endpoint and add server route
- fetch latest players from the frontend
- show recently active players on scores page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b21ddce483249f8716a756795619