### PR TITLE
Update avatar editing on profile

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -48,6 +48,10 @@ const AddButton = styled(IconButton)`
   position: absolute !important;
   bottom: 0;
   right: 0;
+  background-color: white !important;
+  &:hover {
+    background-color: white;
+  }
 `;
 
 const TablesWrapper = styled.div`
@@ -68,6 +72,7 @@ const Profile = () => {
   const [bestTitle, setBestTitle] = useState(null);
   const fileInputRef = useRef(null);
   const { user: loggedUser, setUser: setLoggedUser } = useUser();
+  const isOwnProfile = loggedUser && String(loggedUser.id) === String(id);
 
   const handleAvatarChange = (e) => {
     const file = e.target.files && e.target.files[0];
@@ -170,21 +175,25 @@ const Profile = () => {
                 src={user.avatarUrl || Av}
                 sx={{ width: 80, height: 80 }}
               />
-              <AddButton
-                onClick={() =>
-                  fileInputRef.current && fileInputRef.current.click()
-                }
-                size="small"
-              >
-                <AddIcon fontSize="small" />
-              </AddButton>
-              <input
-                type="file"
-                accept="image/*"
-                ref={fileInputRef}
-                onChange={handleAvatarChange}
-                style={{ display: "none" }}
-              />
+              {isOwnProfile && (
+                <>
+                  <AddButton
+                    onClick={() =>
+                      fileInputRef.current && fileInputRef.current.click()
+                    }
+                    size="small"
+                  >
+                    <AddIcon fontSize="small" />
+                  </AddButton>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    ref={fileInputRef}
+                    onChange={handleAvatarChange}
+                    style={{ display: "none" }}
+                  />
+                </>
+              )}
             </AvatarWrapper>
             <Typography variant="h6" sx={{ mt: 1 }}>
               {user.username}


### PR DESCRIPTION
## Summary
- style AddButton with a white background
- hide avatar upload controls when viewing other profiles

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b49a392c832485c1cd52bfe70c31