### PR TITLE
Add avatar display on leaderboard and scores

### DIFF
--- a/Frontend/src/Pages/Leaderboard/index.jsx
+++ b/Frontend/src/Pages/Leaderboard/index.jsx
@@ -12,9 +12,11 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Avatar,
 } from '@mui/material';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import Av from '../../Assets/anon.png';
 
 const apiClient = new ApiClient();
 
@@ -75,7 +77,10 @@ const Leaderboard = () => {
             {sortedData.map((row) => (
               <TableRow key={row.id}>
                 <TableCell>
-                  <UserLink to={`/profile/${row.id}`}>{row.username}</UserLink>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Avatar src={row.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                    <UserLink to={`/profile/${row.id}`}>{row.username}</UserLink>
+                  </Box>
                 </TableCell>
                 <TableCell align="right">
                   {row.singles ? `LV ${row.singles}` : '-'}

--- a/Frontend/src/Pages/Scores/All.jsx
+++ b/Frontend/src/Pages/Scores/All.jsx
@@ -12,7 +12,10 @@ import {
   TableHead,
   TableRow,
   TablePagination,
+  Avatar,
+  Box,
 } from '@mui/material';
+import Av from '../../Assets/anon.png';
 
 const apiClient = new ApiClient();
 
@@ -46,7 +49,10 @@ const AllScores = () => {
             {scores.map((s) => (
               <TableRow key={s.id}>
                 <TableCell>
-                  <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Avatar src={s.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                    <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                  </Box>
                 </TableCell>
                 <TableCell>{songs[s.song_id]?.title || s.song_id}</TableCell>
                 <TableCell>

--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -5,7 +5,8 @@ import songs from '../../consts/songs.json';
 import styled from 'styled-components';
 import grades from '../../Assets/Grades';
 import { Link } from 'react-router-dom';
-import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import { Table, TableBody, TableCell, TableHead, TableRow, Avatar, Box } from '@mui/material';
+import Av from '../../Assets/anon.png';
 
 const apiClient = new ApiClient();
 
@@ -37,7 +38,10 @@ const Scores = () => {
             {latest.map((s) => (
               <TableRow key={s.id}>
                 <TableCell>
-                  <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Avatar src={s.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                    <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                  </Box>
                 </TableCell>
                 <TableCell>{songs[s.song_id]?.title || s.song_id}</TableCell>
                 <TableCell>
@@ -71,7 +75,10 @@ const Scores = () => {
             {latestPlayers.map((p) => (
               <TableRow key={p.userId}>
                 <TableCell>
-                  <UserLink to={`/profile/${p.userId}`}>{p.user?.username}</UserLink>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Avatar src={p.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                    <UserLink to={`/profile/${p.userId}`}>{p.user?.username}</UserLink>
+                  </Box>
                 </TableCell>
                 <TableCell>{new Date(p.createdAt).toLocaleDateString()}</TableCell>
               </TableRow>

--- a/Server/src/services/leaderboard.service.js
+++ b/Server/src/services/leaderboard.service.js
@@ -14,7 +14,7 @@ const getLeaderboard = async (mode) => {
       const level = parseLevel(s.diff);
       if (level > highest) highest = level;
     });
-    return { id: u.id, username: u.username, highest };
+    return { id: u.id, username: u.username, avatarUrl: u.avatarUrl, highest };
   });
   board.sort((a, b) => b.highest - a.highest);
   return board;
@@ -35,7 +35,7 @@ const getFullLeaderboard = async () => {
       const level = parseLevel(s.diff);
       if (level > doublesHighest) doublesHighest = level;
     });
-    return { id: u.id, username: u.username, singles: singlesHighest, doubles: doublesHighest };
+    return { id: u.id, username: u.username, avatarUrl: u.avatarUrl, singles: singlesHighest, doubles: doublesHighest };
   });
   return board;
 };

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -48,7 +48,7 @@ const getLatestScores = async (limit = 10) =>
     orderBy: { id: 'desc' },
     include: {
       user: {
-        select: { username: true },
+        select: { username: true, avatarUrl: true },
       },
     },
   });
@@ -60,7 +60,7 @@ const getLatestPlayers = async (limit = 10) =>
     take: limit,
     include: {
       user: {
-        select: { username: true },
+        select: { username: true, avatarUrl: true },
       },
     },
   });
@@ -73,7 +73,7 @@ const getAllScores = async (page = 1, limit = 30) => {
     orderBy: { id: 'desc' },
     include: {
       user: {
-        select: { username: true },
+        select: { username: true, avatarUrl: true },
       },
     },
   });


### PR DESCRIPTION
## Summary
- include user avatars in leaderboard and score queries
- show avatars next to user names in leaderboard, latest scores, and all scores pages

## Testing
- `npm --prefix Server test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b59a554483249ec5f81788e18d68