### PR TITLE
Add filters to all scores page

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -34,7 +34,7 @@ export class ApiClient {
     postScores = (mode, data) => client.post(`scores/${mode}`, data)
     getLatestScores = (limit) => client.get('scores/latest', { params: { limit } })
     getLatestPlayers = (limit) => client.get('scores/latestPlayers', { params: { limit } })
-    getAllScores = (page, limit) => client.get('scores/all', { params: { page, limit } })
+    getAllScores = (page, limit, filters = {}) => client.get('scores/all', { params: { page, limit, ...filters } })
 
     getGoals = (mode, userId) => client.get(`goals/${mode}`, { params: userId ? { userId } : {} })
     postGoal = (mode, data) => client.post(`goals/${mode}`, data)

--- a/Frontend/src/Pages/Scores/All.jsx
+++ b/Frontend/src/Pages/Scores/All.jsx
@@ -12,7 +12,10 @@ import {
   TableHead,
   TableRow,
   TablePagination,
+  TextField,
+  Button,
 } from '@mui/material';
+import GradeDropdown from '../../Components/GradeDropdown';
 
 const apiClient = new ApiClient();
 
@@ -20,18 +23,85 @@ const AllScores = () => {
   const [scores, setScores] = useState([]);
   const [page, setPage] = useState(0);
   const [total, setTotal] = useState(0);
+  const [player, setPlayer] = useState('');
+  const [songId, setSongId] = useState('');
+  const [diff, setDiff] = useState('');
+  const [grade, setGrade] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
   const rowsPerPage = 30;
 
-  useEffect(() => {
-    apiClient.getAllScores(page + 1, rowsPerPage).then((res) => {
+  const fetchData = () => {
+    const params = {
+      player: player || undefined,
+      songId: songId || undefined,
+      diff: diff || undefined,
+      grade: grade || undefined,
+      from: from || undefined,
+      to: to || undefined,
+    };
+    apiClient.getAllScores(page + 1, rowsPerPage, params).then((res) => {
       setScores(res.data.results);
       setTotal(res.data.totalResults);
     });
+  };
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
+
+  const handleFilter = () => {
+    setPage(0);
+    fetchData();
+  };
 
   return (
     <>
       <Section header="All scores">
+        <Filters>
+          <TextField
+            label="Player"
+            size="small"
+            value={player}
+            onChange={(e) => setPlayer(e.target.value)}
+          />
+          <TextField
+            label="Song ID"
+            size="small"
+            value={songId}
+            onChange={(e) => setSongId(e.target.value)}
+          />
+          <TextField
+            label="Diff"
+            size="small"
+            value={diff}
+            onChange={(e) => setDiff(e.target.value)}
+          />
+          <GradeDropdown
+            value={grade}
+            onChange={(e) => setGrade(e.target.value)}
+          />
+          <TextField
+            label="From"
+            type="date"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+          />
+          <TextField
+            label="To"
+            type="date"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+          />
+          <Button variant="contained" onClick={handleFilter}>
+            Apply
+          </Button>
+        </Filters>
         <Table size="small">
           <TableHead>
             <TableRow>
@@ -90,4 +160,11 @@ const UserLink = styled(Link)`
   color: inherit;
   text-decoration: underline;
   font-weight: bold;
+`;
+
+const Filters = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
 `;

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -33,7 +33,15 @@ const getLatestPlayers = catchAsync(async (req, res) => {
 const getAllScores = catchAsync(async (req, res) => {
     const page = parseInt(req.query.page, 10) || 1;
     const limit = parseInt(req.query.limit, 10) || 30;
-    const result = await scoresService.getAllScores(page, limit);
+    const filters = pick(req.query, [
+        'player',
+        'songId',
+        'diff',
+        'grade',
+        'from',
+        'to',
+    ]);
+    const result = await scoresService.getAllScores(page, limit, filters);
     res.send(result);
 });
 

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -65,19 +65,43 @@ const getLatestPlayers = async (limit = 10) =>
     },
   });
 
-const getAllScores = async (page = 1, limit = 30) => {
+const getAllScores = async (page = 1, limit = 30, filters = {}) => {
   const skip = (page - 1) * limit;
+  const where = {};
+  if (filters.player) {
+    where.user = { username: { contains: filters.player, mode: 'insensitive' } };
+  }
+  if (filters.songId) {
+    where.song_id = filters.songId;
+  }
+  if (filters.diff) {
+    where.diff = filters.diff;
+  }
+  if (filters.grade) {
+    where.grade = filters.grade;
+  }
+  if (filters.from || filters.to) {
+    where.createdAt = {};
+    if (filters.from) {
+      where.createdAt.gte = new Date(filters.from);
+    }
+    if (filters.to) {
+      where.createdAt.lte = new Date(filters.to);
+    }
+  }
+
   const results = await prisma.score.findMany({
     skip,
     take: limit,
     orderBy: { id: 'desc' },
+    where,
     include: {
       user: {
         select: { username: true },
       },
     },
   });
-  const totalResults = await prisma.score.count();
+  const totalResults = await prisma.score.count({ where });
   const totalPages = Math.ceil(totalResults / limit);
   return { results, page, limit, totalPages, totalResults };
 };

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -34,6 +34,12 @@ const getAllScores = {
   query: Joi.object().keys({
     page: Joi.number().integer(),
     limit: Joi.number().integer(),
+    player: Joi.string(),
+    songId: Joi.string(),
+    diff: Joi.string(),
+    grade: Joi.string(),
+    from: Joi.date(),
+    to: Joi.date(),
   }),
 };
 


### PR DESCRIPTION
## Summary
- add filter controls on All Scores page
- support grade dropdown and date range
- extend HTTP client with filters
- allow filter params in backend validation, controller and service

## Testing
- `npm test` *(fails: jest not found)*
- `npm test --silent --maxWorkers=1` in Frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b567d8788324ba138e621586edab