### PR TITLE
Fix user exposure

### DIFF
--- a/Server/src/controllers/auth.controller.js
+++ b/Server/src/controllers/auth.controller.js
@@ -1,18 +1,19 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
 const { authService, userService, tokenService, emailService } = require('../services');
+const sanitizeUser = require('../utils/sanitizeUser');
 
 const register = catchAsync(async (req, res) => {
   const user = await userService.createUser(req.body);
   const tokens = await tokenService.generateAuthTokens(user);
-  res.status(httpStatus.CREATED).send({ user, tokens });
+  res.status(httpStatus.CREATED).send({ user: sanitizeUser(user), tokens });
 });
 
 const login = catchAsync(async (req, res) => {
   const { username, password } = req.body;
   const user = await authService.loginUserWithUsernameAndPassword(username, password);
   const tokens = await tokenService.generateAuthTokens(user);
-  res.send({ user, tokens });
+  res.send({ user: sanitizeUser(user), tokens });
 });
 
 const logout = catchAsync(async (req, res) => {

--- a/Server/src/controllers/user.controller.js
+++ b/Server/src/controllers/user.controller.js
@@ -3,16 +3,18 @@ const pick = require('../utils/pick');
 const ApiError = require('../utils/ApiError');
 const catchAsync = require('../utils/catchAsync');
 const { userService } = require('../services');
+const sanitizeUser = require('../utils/sanitizeUser');
 
 const createUser = catchAsync(async (req, res) => {
   const user = await userService.createUser(req.body);
-  res.status(httpStatus.CREATED).send(user);
+  res.status(httpStatus.CREATED).send(sanitizeUser(user));
 });
 
 const getUsers = catchAsync(async (req, res) => {
   const filter = pick(req.query, ['name', 'role']);
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
   const result = await userService.queryUsers(filter, options);
+  result.results = result.results.map((u) => sanitizeUser(u));
   res.send(result);
 });
 
@@ -21,12 +23,12 @@ const getUser = catchAsync(async (req, res) => {
   if (!user) {
     throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
   }
-  res.send(user);
+  res.send(sanitizeUser(user));
 });
 
 const updateUser = catchAsync(async (req, res) => {
   const user = await userService.updateUserById(req.params.userId, req.body);
-  res.send(user);
+  res.send(sanitizeUser(user));
 });
 
 const deleteUser = catchAsync(async (req, res) => {

--- a/Server/src/utils/sanitizeUser.js
+++ b/Server/src/utils/sanitizeUser.js
@@ -1,0 +1,16 @@
+/**
+ * Remove sensitive information from user object before sending it in API responses
+ * @param {Object} user
+ * @returns {Object}
+ */
+function sanitizeUser(user) {
+  if (!user) {
+    return user;
+  }
+  // Exclude password and tokens relations if present
+  // eslint-disable-next-line no-unused-vars
+  const { password, tokens, ...publicData } = user;
+  return publicData;
+}
+
+module.exports = sanitizeUser;


### PR DESCRIPTION
## Summary
- sanitize users before sending API responses
- ensure registration and login don't leak password hashes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b5b1705883249b49236c1458a19f