### PR TITLE
Shrink grade select icons

### DIFF
--- a/Frontend/src/Components/GradeDropdown/index.jsx
+++ b/Frontend/src/Components/GradeDropdown/index.jsx
@@ -49,5 +49,5 @@ const GradeDropdown = ({ value, label, onChange }) => {
 export default GradeDropdown;
 
 const Grade = styled.img`
-  height: 35px;
+  height: 30px;
 `;

--- a/Frontend/src/Components/GradeSelect/index.jsx
+++ b/Frontend/src/Components/GradeSelect/index.jsx
@@ -37,7 +37,7 @@ const GradeSelect = ({ value, label, onChange }) => {
 export default GradeSelect
 
 const Grade = styled.img`
-    height: 35px;
+    height: 30px;
 `
 
 const Wrapper = styled.div`


### PR DESCRIPTION
## Summary
- reduce height of grade icons to shrink grade selector visuals

## Testing
- `npm test --prefix Frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878bafe792483249e0464208d88fa3c