### PR TITLE
Implement score session tracking

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -48,6 +48,11 @@ export class ApiClient {
 
     getRating = (songId, diff) => client.get(`ratings/${songId}/${diff}`)
     postRating = (data) => client.post('ratings', data)
+
+    getCurrentSession = () => client.get('sessions/current')
+    endSession = () => client.post('sessions/end')
+    cancelSession = () => client.post('sessions/cancel')
+    listSessions = (userId) => client.get('sessions', { params: userId ? { userId } : {} })
 }
 
 export default client

--- a/Frontend/src/Components/Layout/index.jsx
+++ b/Frontend/src/Components/Layout/index.jsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router";
 import Navbar from "../Navigation";
 import NotificationProvider from "../Notification";
 import UserProvider from "../User";
+import SessionBanner from "../SessionBanner";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import { Box, GlobalStyles } from "@mui/material";
@@ -59,6 +60,7 @@ const Layout = () => {
             />
             <div>
               <Navbar />
+              <SessionBanner />
               <Box
                 sx={{
                   padding: {

--- a/Frontend/src/Components/SessionBanner.jsx
+++ b/Frontend/src/Components/SessionBanner.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import { ApiClient } from "../API/httpService";
+import { Link } from "react-router-dom";
+import { Box } from "@mui/material";
+
+const api = new ApiClient();
+
+const SessionBanner = () => {
+  const [sessionId, setSessionId] = useState(null);
+  useEffect(() => {
+    api
+      .getCurrentSession()
+      .then((r) => {
+        if (r.status === 204) setSessionId(null);
+        else setSessionId(r.data.id);
+      })
+      .catch(() => setSessionId(null));
+  }, []);
+  if (!sessionId) return null;
+  return (
+    <Box sx={{ textAlign: "center", p: 1, backgroundColor: "#ffc" }}>
+      <Link to="/session">See your current session</Link>
+    </Box>
+  );
+};
+
+export default SessionBanner;

--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -76,6 +76,7 @@ const Profile = () => {
   const [singleGoals, setSingleGoals] = useState([]);
   const [doubleGoals, setDoubleGoals] = useState([]);
   const [bestTitle, setBestTitle] = useState(null);
+  const [sessions, setSessions] = useState([]);
   const [showAvatarInput, setShowAvatarInput] = useState(false);
   const [avatarUrlInput, setAvatarUrlInput] = useState("");
   const { user: loggedUser, setUser: setLoggedUser } = useUser();
@@ -105,6 +106,7 @@ const Profile = () => {
     apiClient.getScores(MODES.DOUBLE, id).then((r) => setDoubleScores(r.data));
     apiClient.getGoals(MODES.SINGLE, id).then((r) => setSingleGoals(r.data));
     apiClient.getGoals(MODES.DOUBLE, id).then((r) => setDoubleGoals(r.data));
+    apiClient.listSessions(id).then((r) => setSessions(r.data));
   }, [id]);
 
   const getAdiff = (songId, diff, mode) => {
@@ -226,6 +228,30 @@ const Profile = () => {
           </Box>
         )}
       </Section>
+      {sessions.length > 0 && (
+        <Section header="Your sessions">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Start</TableCell>
+                <TableCell>Duration</TableCell>
+                <TableCell>Scores</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {sessions.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
+                  <TableCell>
+                    {Math.round((new Date(s.endedAt || s.lastScore) - new Date(s.startedAt)) / 60000)}m
+                  </TableCell>
+                  <TableCell>{s._count?.scores || s.scores?.length || 0}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Section>
+      )}
       <Section header="Best passes">
         <TablesWrapper>
           <Table size="small">

--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { ApiClient } from "../../API/httpService";
+import songs from "../../consts/songs.json";
+import grades from "../../Assets/Grades";
+import stepball from "../../Assets/Diffs";
+import { Table, TableBody, TableCell, TableHead, TableRow, Button, Box } from "@mui/material";
+import { Link } from "react-router-dom";
+
+const api = new ApiClient();
+
+const SessionPage = () => {
+  const [session, setSession] = useState(null);
+
+  const load = () => {
+    api
+      .getCurrentSession()
+      .then((r) => {
+        if (r.status === 204) setSession(null);
+        else setSession(r.data);
+      })
+      .catch(() => setSession(null));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const endSession = () => {
+    api.endSession().then(() => load());
+  };
+
+  const cancelSession = () => {
+    api.cancelSession().then(() => load());
+  };
+
+  if (!session) return <p>No active session</p>;
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2 }}>
+        <Button onClick={endSession} variant="contained" sx={{ mr: 1 }}>
+          End Session
+        </Button>
+        <Button onClick={cancelSession} variant="outlined">
+          Cancel Session
+        </Button>
+      </Box>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Song</TableCell>
+            <TableCell>Grade</TableCell>
+            <TableCell>Diff</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {session.scores.map((s) => (
+            <TableRow key={s.id}>
+              <TableCell>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <img src={songs[s.song_id]?.img} alt="cover" width={40} />
+                  <Link to={`/song/${s.song_id}/${s.mode}/${s.diff}`}>{songs[s.song_id]?.title || s.song_id}</Link>
+                </Box>
+              </TableCell>
+              <TableCell>
+                {s.grade ? <img src={grades[s.grade]} alt={s.grade} height={30} /> : "-"}
+              </TableCell>
+              <TableCell>
+                <img src={stepball[s.mode === "item_double" ? "double" : "single"]} alt={s.diff} width={30} className={s.diff} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+export default SessionPage;

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -10,6 +10,7 @@ import Scores from '../Pages/Scores'
 import AllScores from '../Pages/Scores/All'
 import Leaderboard from '../Pages/Leaderboard'
 import Titles from '../Pages/Titles'
+import SessionPage from '../Pages/Session'
 // import { useDispatch, useSelector } from 'react-redux'
 import Login from '../Pages/Login'
 import Profile from '../Pages/Profile'
@@ -42,6 +43,10 @@ const router = createHashRouter([
             {
                 path: 'ScoresAll',
                 element: <AllScores />
+            },
+            {
+                path: 'session',
+                element: <SessionPage />
             },
             {
                 path: 'Leaderboard',

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -45,6 +45,20 @@ model Score {
   grade     String?
   mode      String
   createdAt DateTime @default(now())
+  sessionId Int?
+  session   Session? @relation(fields: [sessionId], references: [id])
+}
+
+model Session {
+  id        Int       @id @default(autoincrement())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id])
+  startedAt DateTime  @default(now())
+  lastScore DateTime
+  endedAt   DateTime?
+  scores    Score[]
+
+  @@index([userId, endedAt])
 }
 
 model Missing {

--- a/Server/src/controllers/index.js
+++ b/Server/src/controllers/index.js
@@ -5,3 +5,4 @@ module.exports.leaderboardController = require('./leaderboard.controller');
 module.exports.missingController = require('./missing.controller');
 module.exports.ratingsController = require('./ratings.controller');
 module.exports.goalsController = require('./goals.controller');
+module.exports.sessionsController = require('./sessions.controller');

--- a/Server/src/controllers/sessions.controller.js
+++ b/Server/src/controllers/sessions.controller.js
@@ -1,0 +1,29 @@
+const catchAsync = require('../utils/catchAsync');
+const httpStatus = require('http-status');
+const { sessionService } = require('../services');
+
+const getCurrent = catchAsync(async (req, res) => {
+  const session = await sessionService.getCurrent(req.user.id);
+  if (!session) {
+    return res.status(httpStatus.NO_CONTENT).send();
+  }
+  res.send(session);
+});
+
+const endSession = catchAsync(async (req, res) => {
+  await sessionService.endSession(req.user.id);
+  res.status(httpStatus.NO_CONTENT).send();
+});
+
+const cancelSession = catchAsync(async (req, res) => {
+  await sessionService.cancelSession(req.user.id);
+  res.status(httpStatus.NO_CONTENT).send();
+});
+
+const listSessions = catchAsync(async (req, res) => {
+  const userId = req.query.userId || req.user.id;
+  const sessions = await sessionService.listSessions(userId);
+  res.send(sessions);
+});
+
+module.exports = { getCurrent, endSession, cancelSession, listSessions };

--- a/Server/src/routes/v1/index.js
+++ b/Server/src/routes/v1/index.js
@@ -7,6 +7,7 @@ const leaderboardRoute = require('./leaderboard.route');
 const missingRoute = require('./missing.route');
 const ratingsRoute = require('./ratings.route');
 const goalsRoute = require('./goals.route');
+const sessionsRoute = require('./sessions.route');
 const config = require('../../config/config');
 
 const router = express.Router();
@@ -39,6 +40,10 @@ const defaultRoutes = [
   {
     path: '/goals',
     route: goalsRoute,
+  },
+  {
+    path: '/sessions',
+    route: sessionsRoute,
   },
 ];
 

--- a/Server/src/routes/v1/sessions.route.js
+++ b/Server/src/routes/v1/sessions.route.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const auth = require('../../middlewares/auth');
+const sessionsController = require('../../controllers/sessions.controller');
+
+const router = express.Router();
+
+router.get('/current', auth('getScores'), sessionsController.getCurrent);
+router.post('/end', auth('postScores'), sessionsController.endSession);
+router.post('/cancel', auth('postScores'), sessionsController.cancelSession);
+router.get('/', auth('getScores'), sessionsController.listSessions);
+
+module.exports = router;

--- a/Server/src/services/index.js
+++ b/Server/src/services/index.js
@@ -8,3 +8,4 @@ module.exports.achievementService = require('./achievement.service');
 module.exports.missingService = require('./missing.service');
 module.exports.ratingsService = require('./ratings.service');
 module.exports.goalsService = require('./goals.service');
+module.exports.sessionService = require('./session.service');

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -1,5 +1,6 @@
 const prisma = require('../db');
 const achievementService = require('./achievement.service');
+const { sessionService } = require('./index');
 
 const getScores = async (filter) => {
   const scores = await prisma.score.findMany({ where: { userId: filter.userId, mode: filter.mode } });
@@ -35,10 +36,12 @@ const createScore = async (scoreBody, mode, user) => {
   if (existing) {
     const res = await prisma.score.update({ where: { id: existing.id }, data: { grade } });
     const { newBadges, newTitles } = await achievementService.updateUserAchievements(user.id, res);
+    await sessionService.handleScore(user.id, res.id);
     return { score: res, newBadges, newTitles };
   }
   const res = await prisma.score.create({ data: { song_id, diff, grade, userId: user.id, mode } });
   const { newBadges, newTitles } = await achievementService.updateUserAchievements(user.id, res);
+  await sessionService.handleScore(user.id, res.id);
   return { score: res, newBadges, newTitles };
 };
 

--- a/Server/src/services/session.service.js
+++ b/Server/src/services/session.service.js
@@ -1,0 +1,68 @@
+const prisma = require('../db');
+
+const SESSION_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+const START_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+
+const handleScore = async (userId, scoreId) => {
+  const now = new Date();
+  let session = await prisma.session.findFirst({
+    where: { userId, endedAt: null },
+  });
+  if (session) {
+    if (now - session.lastScore.getTime() > SESSION_TIMEOUT_MS) {
+      await prisma.session.update({
+        where: { id: session.id },
+        data: { endedAt: session.lastScore },
+      });
+      session = null;
+    }
+  }
+  if (session) {
+    await prisma.score.update({ where: { id: scoreId }, data: { sessionId: session.id } });
+    await prisma.session.update({ where: { id: session.id }, data: { lastScore: now } });
+    return session;
+  }
+
+  const threshold = new Date(now.getTime() - START_THRESHOLD_MS);
+  const recent = await prisma.score.findMany({
+    where: { userId, sessionId: null, createdAt: { gte: threshold } },
+    orderBy: { createdAt: 'asc' },
+    take: 2,
+  });
+  if (recent.length >= 2) {
+    session = await prisma.session.create({
+      data: { userId, startedAt: recent[0].createdAt, lastScore: now },
+    });
+    const ids = recent.map((s) => s.id).concat(scoreId);
+    await prisma.score.updateMany({ where: { id: { in: ids } }, data: { sessionId: session.id } });
+    return session;
+  }
+  return null;
+};
+
+const getCurrent = async (userId) =>
+  prisma.session.findFirst({ where: { userId, endedAt: null }, include: { scores: true } });
+
+const endSession = async (userId) => {
+  const session = await prisma.session.findFirst({ where: { userId, endedAt: null } });
+  if (!session) return null;
+  return prisma.session.update({ where: { id: session.id }, data: { endedAt: new Date() } });
+};
+
+const cancelSession = async (userId) => {
+  const session = await prisma.session.findFirst({ where: { userId, endedAt: null } });
+  if (!session) return null;
+  const id = session.id;
+  await prisma.score.updateMany({ where: { sessionId: id }, data: { sessionId: null } });
+  await prisma.session.delete({ where: { id } });
+  return null;
+};
+
+const listSessions = async (userId) =>
+  prisma.session.findMany({
+    where: { userId },
+    orderBy: { startedAt: 'desc' },
+    include: { _count: { select: { scores: true } } },
+  });
+
+module.exports = { handleScore, getCurrent, endSession, cancelSession, listSessions };

--- a/Server/src/validations/index.js
+++ b/Server/src/validations/index.js
@@ -3,3 +3,5 @@ module.exports.userValidation = require('./user.validation');
 module.exports.scoresValidation = require('./scores.validation');
 module.exports.missingValidation = require('./missing.validation');
 module.exports.ratingsValidation = require('./ratings.validation');
+module.exports.goalsValidation = require('./goals.validation');
+module.exports.sessionsValidation = require('./sessions.validation');

--- a/Server/src/validations/sessions.validation.js
+++ b/Server/src/validations/sessions.validation.js
@@ -1,0 +1,9 @@
+const Joi = require('joi');
+
+const listSessions = {
+  query: Joi.object().keys({
+    userId: Joi.string(),
+  }),
+};
+
+module.exports = { listSessions };


### PR DESCRIPTION
## Summary
- add Session model and related service
- record score sessions on the backend and expose endpoints
- add session banner and page on frontend
- list user's sessions on profile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c73cc4108324821d732261a62372