### PR TITLE
Fix grade sort order

### DIFF
--- a/Frontend/src/helpers/compareGrades.js
+++ b/Frontend/src/helpers/compareGrades.js
@@ -1,4 +1,19 @@
-const gradeOrder = ['SSS', 'SS', 'S', 'Ap', 'A', "Bp", "B", "Cp", 'C', "Dp", "D", "F"]
+// Grade order from best to worst
+// SSS > SS > S > Ap > Bp > Cp > Dp > A > B > C > D > F
+const gradeOrder = [
+    'SSS',
+    'SS',
+    'S',
+    'Ap',
+    'Bp',
+    'Cp',
+    'Dp',
+    'A',
+    'B',
+    'C',
+    'D',
+    'F',
+]
 
 const compareGrades = (a, b) => {
     if (!b) return -1

--- a/Server/src/services/achievement.service.js
+++ b/Server/src/services/achievement.service.js
@@ -4,7 +4,22 @@ const { clearTitles } = require('../consts/titleRequirements');
 
 const songs = require('./songs.json');
 
-const gradeOrder = ['SSS', 'SS', 'S', 'Ap', 'A', 'Bp', 'B', 'Cp', 'C', 'Dp', 'D', 'F'];
+// Grade order from best to worst used when comparing achievements
+// SSS > SS > S > Ap > Bp > Cp > Dp > A > B > C > D > F
+const gradeOrder = [
+  'SSS',
+  'SS',
+  'S',
+  'Ap',
+  'Bp',
+  'Cp',
+  'Dp',
+  'A',
+  'B',
+  'C',
+  'D',
+  'F',
+];
 const gradeBetterOrEqual = (a, b) => {
   if (!a) return false;
   return gradeOrder.indexOf(a) <= gradeOrder.indexOf(b);


### PR DESCRIPTION
## Summary
- add missing newline & update grade order constant in `compareGrades.js`
- adjust server achievement service grade order

## Testing
- `npm test` *(fails: jest not found)*
- `npm test --silent --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c7bbe4008324bb7c6010706fabdb