### PR TITLE
Fix dropdown height

### DIFF
--- a/Frontend/src/Components/GradeDropdown/index.jsx
+++ b/Frontend/src/Components/GradeDropdown/index.jsx
@@ -3,9 +3,15 @@ import React from "react";
 import styled from "styled-components";
 import grades from "../../Assets/Grades";
 
-const GradeDropdown = ({ value, label, onChange }) => {
+const GradeDropdown = ({ value, label, onChange, size = "small" }) => {
   return (
-    <Select value={value} label={label} onChange={onChange} defaultValue={"Ap"}>
+    <Select
+      value={value}
+      label={label}
+      onChange={onChange}
+      defaultValue={"Ap"}
+      size={size}
+    >
       <MenuItem value={"SSS"}>
         <Grade src={grades.SSS} />
       </MenuItem>


### PR DESCRIPTION
## Summary
- make `GradeDropdown` use `size="small"`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c7e0a6f08324a8b13c4342fcaff7