### PR TITLE
Fix diffball display on session page

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -2,11 +2,17 @@ import React, { useEffect, useState } from "react";
 import { ApiClient } from "../../API/httpService";
 import songs from "../../consts/songs.json";
 import grades from "../../Assets/Grades";
-import stepball from "../../Assets/Diffs";
 import { Table, TableBody, TableCell, TableHead, TableRow, Button, Box } from "@mui/material";
 import { Link } from "react-router-dom";
+import styled from "styled-components";
 
 const api = new ApiClient();
+
+const DiffBall = styled.span`
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+`;
 
 const SessionPage = () => {
   const [session, setSession] = useState(null);
@@ -66,7 +72,7 @@ const SessionPage = () => {
                 {s.grade ? <img src={grades[s.grade]} alt={s.grade} height={30} /> : "-"}
               </TableCell>
               <TableCell>
-                <img src={stepball[s.mode === "item_double" ? "double" : "single"]} alt={s.diff} width={30} className={s.diff} />
+                <DiffBall className={`${s.mode} ${s.diff}`} />
               </TableCell>
             </TableRow>
           ))}


### PR DESCRIPTION
## Summary
- use DiffBall component instead of `<img>` for difficulty display

## Testing
- `npm test` *(fails: jest not found)*
- `npm test -- -w=0` in Frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cbcf102883248f9f9c12495c97b6