### PR TITLE
Add score history with delete option

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -37,6 +37,11 @@ export class ApiClient {
     getAllScores = (page, limit, filters = {}, sortBy) =>
         client.get('scores/all', { params: { page, limit, sortBy, ...filters } })
 
+    getScoreHistory = (mode, songId, diff, userId) =>
+        client.get(`scores/history/${mode}/${songId}/${diff}`, { params: userId ? { userId } : {} })
+
+    deleteScore = (id) => client.delete(`scores/${id}`)
+
     getGoals = (mode, userId) => client.get(`goals/${mode}`, { params: userId ? { userId } : {} })
     postGoal = (mode, data) => client.post(`goals/${mode}`, data)
 

--- a/Frontend/src/Components/GradeSelect/index.jsx
+++ b/Frontend/src/Components/GradeSelect/index.jsx
@@ -30,7 +30,6 @@ const GradeSelect = ({ value, label, onChange }) => {
         >
             {otherGrades.map(g => <MenuItem key={g} value={g}><Grade src={grades[g]} /></MenuItem>)}
         </Select>
-        {value && <Button onClick={() => onChange('')}>Remove</Button>}
     </Wrapper>
 }
 

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -1,14 +1,31 @@
 import React, { useMemo, useState, useEffect } from "react";
-import { Box, Typography, Divider, Button, IconButton } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Divider,
+  Button,
+  IconButton,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ClearIcon from "@mui/icons-material/Clear";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
+import grades from "../../Assets/Grades";
 
 import styled from "styled-components";
 import GradeSelect from "../../Components/GradeSelect";
 import packs from "../../consts/packs";
 import { ApiClient } from "../../API/httpService";
 
-const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff }) => {
+const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history = [], removeScore }) => {
   const [grade, setGrade] = useState(chart.grade || "");
   const loggedIn = Boolean(localStorage.getItem("token"));
   const [ratings, setRatings] = useState({ harder: 0, ok: 0, easier: 0 });
@@ -149,6 +166,50 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff }) => {
             </DiffList>
           </>
         )}
+        {history.length > 0 && (
+          <>
+            <Divider sx={{ my: 2 }} />
+            <Accordion>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography>Play History</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Grade</TableCell>
+                      <TableCell>Date / Time</TableCell>
+                      {removeScore && <TableCell />}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {history.map((h) => (
+                      <TableRow key={h.id}>
+                        <TableCell>
+                          {h.grade ? (
+                            <GradeIcon src={grades[h.grade]} alt={h.grade} />
+                          ) : (
+                            "-"
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {new Date(h.createdAt).toLocaleString()}
+                        </TableCell>
+                        {removeScore && (
+                          <TableCell>
+                            <IconButton size="small" onClick={() => removeScore(h.id)}>
+                              <ClearIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </AccordionDetails>
+            </Accordion>
+          </>
+        )}
       </Content>
     </Container>
   );
@@ -255,4 +316,9 @@ const RatingBar = styled.div`
 
 const Segment = styled.div`
   height: 100%;
+`;
+
+const GradeIcon = styled.img`
+  height: 20px;
+  vertical-align: middle;
 `;

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -13,9 +13,26 @@ const getScores = catchAsync(async (req, res) => {
     res.send(result);
 });
 
+const getScoreHistory = catchAsync(async (req, res) => {
+    const mode = req.params.mode;
+    const { songId, diff } = req.params;
+    const userId = req.query.userId || req.user.id;
+    const history = await scoresService.getScoreHistory(userId, mode, songId, diff);
+    res.send(history);
+});
+
 const postScore = catchAsync(async (req, res) => {
     const result = await scoresService.createScore(req.body, req.params.mode, req.user);
     res.status(httpStatus.CREATED).send(result);
+});
+
+const deleteScore = catchAsync(async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    const removed = await scoresService.deleteScore(id, req.user.id);
+    if (!removed) {
+        throw new ApiError(httpStatus.NOT_FOUND, 'Score not found');
+    }
+    res.status(httpStatus.NO_CONTENT).send();
 });
 
 const getLatestScores = catchAsync(async (req, res) => {
@@ -49,7 +66,9 @@ const getAllScores = catchAsync(async (req, res) => {
 
 module.exports = {
     getScores,
+    getScoreHistory,
     postScore,
+    deleteScore,
     getLatestScores,
     getLatestPlayers,
     getAllScores,

--- a/Server/src/routes/v1/scores.route.js
+++ b/Server/src/routes/v1/scores.route.js
@@ -19,6 +19,18 @@ router
   .get(validate(scoresValidation.getAllScores), scoresController.getAllScores);
 
 router
+  .route('/history/:mode/:songId/:diff')
+  .get(
+    auth('getScores'),
+    validate(scoresValidation.getScoreHistory),
+    scoresController.getScoreHistory,
+  );
+
+router
+  .route('/:id')
+  .delete(auth('postScores'), validate(scoresValidation.deleteScore), scoresController.deleteScore);
+
+router
   .route('/:mode')
   .post(auth('postScores'), validate(scoresValidation.createScore), scoresController.postScore)
   .get(auth('getScores'), validate(scoresValidation.getScores), scoresController.getScores);

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -18,6 +18,17 @@ const getScores = {
   }),
 };
 
+const getScoreHistory = {
+  params: Joi.object().keys({
+    mode: Joi.string(),
+    songId: Joi.string().required(),
+    diff: Joi.string().required(),
+  }),
+  query: Joi.object().keys({
+    userId: Joi.string(),
+  }),
+};
+
 const getLatestScores = {
   query: Joi.object().keys({
     limit: Joi.number(),
@@ -45,10 +56,18 @@ const getAllScores = {
   }),
 };
 
+const deleteScore = {
+  params: Joi.object().keys({
+    id: Joi.number().integer().required(),
+  }),
+};
+
 module.exports = {
   createScore,
   getScores,
+  getScoreHistory,
   getLatestScores,
   getLatestPlayers,
   getAllScores,
+  deleteScore,
 };


### PR DESCRIPTION
## Summary
- keep all posted scores as history
- return best grade per song
- expose play history and delete score endpoints
- fetch play history in the song page and show in a collapsible panel
- allow removing scores from history
- remove the grade select "Remove" button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cb1d92a48324aebf8f4221615718