### PR TITLE
Add session list page and improve banner

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -53,6 +53,7 @@ export class ApiClient {
     endSession = () => client.post('sessions/end')
     cancelSession = () => client.post('sessions/cancel')
     listSessions = (userId) => client.get('sessions', { params: userId ? { userId } : {} })
+    getSession = (id) => client.get(`sessions/${id}`)
 }
 
 export default client

--- a/Frontend/src/Components/SessionBanner.jsx
+++ b/Frontend/src/Components/SessionBanner.jsx
@@ -8,13 +8,18 @@ const api = new ApiClient();
 const SessionBanner = () => {
   const [sessionId, setSessionId] = useState(null);
   useEffect(() => {
-    api
-      .getCurrentSession()
-      .then((r) => {
-        if (r.status === 204) setSessionId(null);
-        else setSessionId(r.data.id);
-      })
-      .catch(() => setSessionId(null));
+    const load = () => {
+      api
+        .getCurrentSession()
+        .then((r) => {
+          if (r.status === 204) setSessionId(null);
+          else setSessionId(r.data.id);
+        })
+        .catch(() => setSessionId(null));
+    };
+    load();
+    const interval = setInterval(load, 30000);
+    return () => clearInterval(interval);
   }, []);
   if (!sessionId) return null;
   return (

--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -240,7 +240,7 @@ const Profile = () => {
             </TableHead>
             <TableBody>
               {sessions.map((s) => (
-                <TableRow key={s.id}>
+                <TableRow key={s.id} component={Link} to={`/session/${s.id}`}>
                   <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
                   <TableCell>
                     {Math.round((new Date(s.endedAt || s.lastScore) - new Date(s.startedAt)) / 60000)}m
@@ -250,6 +250,9 @@ const Profile = () => {
               ))}
             </TableBody>
           </Table>
+          <Box sx={{ mt: 1 }}>
+            <Link to={`/sessions/${id}`}>Show all sessions</Link>
+          </Box>
         </Section>
       )}
       <Section header="Best passes">

--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -4,16 +4,17 @@ import songs from "../../consts/songs.json";
 import grades from "../../Assets/Grades";
 import stepball from "../../Assets/Diffs";
 import { Table, TableBody, TableCell, TableHead, TableRow, Button, Box } from "@mui/material";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 const api = new ApiClient();
 
 const SessionPage = () => {
+  const { id } = useParams();
   const [session, setSession] = useState(null);
 
   const load = () => {
-    api
-      .getCurrentSession()
+    const req = id ? api.getSession(id) : api.getCurrentSession();
+    req
       .then((r) => {
         if (r.status === 204) setSession(null);
         else setSession(r.data);
@@ -23,7 +24,7 @@ const SessionPage = () => {
 
   useEffect(() => {
     load();
-  }, []);
+  }, [id]);
 
   const endSession = () => {
     api.endSession().then(() => load());
@@ -33,18 +34,21 @@ const SessionPage = () => {
     api.cancelSession().then(() => load());
   };
 
-  if (!session) return <p>No active session</p>;
+  if (!session)
+    return <p>{id ? 'Session not found' : 'No active session'}</p>;
 
   return (
     <Box>
-      <Box sx={{ mb: 2 }}>
-        <Button onClick={endSession} variant="contained" sx={{ mr: 1 }}>
-          End Session
-        </Button>
-        <Button onClick={cancelSession} variant="outlined">
-          Cancel Session
-        </Button>
-      </Box>
+      {!id && (
+        <Box sx={{ mb: 2 }}>
+          <Button onClick={endSession} variant="contained" sx={{ mr: 1 }}>
+            End Session
+          </Button>
+          <Button onClick={cancelSession} variant="outlined">
+            Cancel Session
+          </Button>
+        </Box>
+      )}
       <Table size="small">
         <TableHead>
           <TableRow>

--- a/Frontend/src/Pages/Sessions/index.jsx
+++ b/Frontend/src/Pages/Sessions/index.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { ApiClient } from "../../API/httpService";
+import { useParams, Link } from "react-router-dom";
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Box,
+  ToggleButton,
+  ToggleButtonGroup,
+  Paper,
+} from "@mui/material";
+import Section from "../../Components/Layout/Section";
+
+const api = new ApiClient();
+
+const SessionsPage = () => {
+  const { userId } = useParams();
+  const [sessions, setSessions] = useState([]);
+  const [view, setView] = useState("list");
+
+  useEffect(() => {
+    api
+      .listSessions(userId)
+      .then((r) => setSessions(r.data))
+      .catch(() => {});
+  }, [userId]);
+
+  const formatDuration = (s) =>
+    Math.round((new Date(s.endedAt || s.lastScore) - new Date(s.startedAt)) / 60000);
+
+  return (
+    <Section header="Sessions">
+      <ToggleButtonGroup
+        value={view}
+        exclusive
+        onChange={(_, v) => v && setView(v)}
+        sx={{ mb: 2 }}
+      >
+        <ToggleButton value="list">List</ToggleButton>
+        <ToggleButton value="grid">Grid</ToggleButton>
+      </ToggleButtonGroup>
+      {view === "list" ? (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Start</TableCell>
+              <TableCell>Duration</TableCell>
+              <TableCell>Scores</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sessions.map((s) => (
+              <TableRow key={s.id} component={Link} to={`/session/${s.id}`}>
+                <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
+                <TableCell>{formatDuration(s)}m</TableCell>
+                <TableCell>{s._count?.scores || s.scores?.length || 0}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+          {sessions.map((s) => (
+            <Paper
+              key={s.id}
+              component={Link}
+              to={`/session/${s.id}`}
+              sx={{ p: 2, textDecoration: "none" }}
+            >
+              <div>{new Date(s.startedAt).toLocaleString()}</div>
+              <div>{formatDuration(s)}m</div>
+              <div>{s._count?.scores || s.scores?.length || 0} scores</div>
+            </Paper>
+          ))}
+        </Box>
+      )}
+    </Section>
+  );
+};
+
+export default SessionsPage;
+

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -11,6 +11,7 @@ import AllScores from '../Pages/Scores/All'
 import Leaderboard from '../Pages/Leaderboard'
 import Titles from '../Pages/Titles'
 import SessionPage from '../Pages/Session'
+import SessionsPage from '../Pages/Sessions'
 // import { useDispatch, useSelector } from 'react-redux'
 import Login from '../Pages/Login'
 import Profile from '../Pages/Profile'
@@ -47,6 +48,14 @@ const router = createHashRouter([
             {
                 path: 'session',
                 element: <SessionPage />
+            },
+            {
+                path: 'session/:id',
+                element: <SessionPage />
+            },
+            {
+                path: 'sessions/:userId',
+                element: <SessionsPage />
             },
             {
                 path: 'Leaderboard',

--- a/Server/src/controllers/sessions.controller.js
+++ b/Server/src/controllers/sessions.controller.js
@@ -26,4 +26,12 @@ const listSessions = catchAsync(async (req, res) => {
   res.send(sessions);
 });
 
-module.exports = { getCurrent, endSession, cancelSession, listSessions };
+const getSession = catchAsync(async (req, res) => {
+  const session = await sessionService.getSession(req.params.id);
+  if (!session) {
+    return res.status(httpStatus.NOT_FOUND).send();
+  }
+  res.send(session);
+});
+
+module.exports = { getCurrent, endSession, cancelSession, listSessions, getSession };

--- a/Server/src/routes/v1/sessions.route.js
+++ b/Server/src/routes/v1/sessions.route.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const auth = require('../../middlewares/auth');
 const sessionsController = require('../../controllers/sessions.controller');
+const validate = require('../../middlewares/validate');
+const sessionsValidation = require('../../validations/sessions.validation');
 
 const router = express.Router();
 
@@ -8,5 +10,6 @@ router.get('/current', auth('getScores'), sessionsController.getCurrent);
 router.post('/end', auth('postScores'), sessionsController.endSession);
 router.post('/cancel', auth('postScores'), sessionsController.cancelSession);
 router.get('/', auth('getScores'), sessionsController.listSessions);
+router.get('/:id', auth('getScores'), validate(sessionsValidation.getSession), sessionsController.getSession);
 
 module.exports = router;

--- a/Server/src/services/session.service.js
+++ b/Server/src/services/session.service.js
@@ -65,4 +65,7 @@ const listSessions = async (userId) =>
     include: { _count: { select: { scores: true } } },
   });
 
-module.exports = { handleScore, getCurrent, endSession, cancelSession, listSessions };
+const getSession = async (id) =>
+  prisma.session.findUnique({ where: { id: Number(id) }, include: { scores: true } });
+
+module.exports = { handleScore, getCurrent, endSession, cancelSession, listSessions, getSession };

--- a/Server/src/validations/sessions.validation.js
+++ b/Server/src/validations/sessions.validation.js
@@ -6,4 +6,10 @@ const listSessions = {
   }),
 };
 
-module.exports = { listSessions };
+const getSession = {
+  params: Joi.object().keys({
+    id: Joi.number().required(),
+  }),
+};
+
+module.exports = { listSessions, getSession };


### PR DESCRIPTION
## Summary
- auto-refresh the session banner every 30s
- allow opening historical sessions via `/session/:id`
- create sessions page with list/grid switch
- link to sessions page from profile and make session rows clickable
- add backend endpoint to fetch session by ID

## Testing
- `npm test` *(fails: `jest: not found`)*
- `npm test --silent` in Frontend *(fails: `react-scripts: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_6878cb7cbc408324ab3e333555a792f9