### PR TITLE
Implement session deletion and view toggle

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -59,6 +59,7 @@ export class ApiClient {
     cancelSession = () => client.post('sessions/cancel')
     listSessions = (userId) => client.get('sessions', { params: userId ? { userId } : {} })
     getSession = (id) => client.get(`sessions/${id}`)
+    deleteSession = (id) => client.delete(`sessions/${id}`)
 }
 
 export default client

--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -2,8 +2,20 @@ import React, { useEffect, useState } from "react";
 import { ApiClient } from "../../API/httpService";
 import songs from "../../consts/songs.json";
 import grades from "../../Assets/Grades";
-import { Table, TableBody, TableCell, TableHead, TableRow, Button, Box } from "@mui/material";
-import { Link, useParams } from "react-router-dom";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Button,
+  Box,
+  ToggleButton,
+  ToggleButtonGroup,
+  Paper,
+} from "@mui/material";
+import { Link, useParams, useNavigate } from "react-router-dom";
+import { useUser } from "../../Components/User";
 import styled from "styled-components";
 
 const api = new ApiClient();
@@ -17,6 +29,10 @@ const DiffBall = styled.span`
 const SessionPage = () => {
   const { id } = useParams();
   const [session, setSession] = useState(null);
+  const [view, setView] = useState("list");
+  const navigate = useNavigate();
+  const { user } = useUser();
+  const isOwn = user && session && String(user.id) === String(session.userId);
 
   const load = () => {
     const req = id ? api.getSession(id) : api.getCurrentSession();
@@ -40,50 +56,91 @@ const SessionPage = () => {
     api.cancelSession().then(() => load());
   };
 
+  const removeSession = () => {
+    if (!id) return;
+    api.deleteSession(id).then(() => {
+      if (user) navigate(`/sessions/${user.id}`);
+    });
+  };
+
   if (!session)
     return <p>{id ? 'Session not found' : 'No active session'}</p>;
 
   return (
-    <Box>
-      {!id && (
-        <Box sx={{ mb: 2 }}>
-          <Button onClick={endSession} variant="contained" sx={{ mr: 1 }}>
-            End Session
-          </Button>
-          <Button onClick={cancelSession} variant="outlined">
-            Cancel Session
-          </Button>
-        </Box>
-      )}
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Song</TableCell>
-            <TableCell>Grade</TableCell>
-            <TableCell>Diff</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {session.scores.map((s) => (
-            <TableRow key={s.id}>
-              <TableCell>
+      <Box>
+        {!id && (
+          <Box sx={{ mb: 2 }}>
+            <Button onClick={endSession} variant="contained" sx={{ mr: 1 }}>
+              End Session
+            </Button>
+            <Button onClick={cancelSession} variant="outlined">
+              Cancel Session
+            </Button>
+          </Box>
+        )}
+        {id && isOwn && (
+          <Box sx={{ mb: 2 }}>
+            <Button onClick={removeSession} variant="outlined" color="error">
+              Delete Session
+            </Button>
+          </Box>
+        )}
+        <ToggleButtonGroup
+          value={view}
+          exclusive
+          onChange={(_, v) => v && setView(v)}
+          sx={{ mb: 2 }}
+        >
+          <ToggleButton value="list">List</ToggleButton>
+          <ToggleButton value="grid">Grid</ToggleButton>
+        </ToggleButtonGroup>
+        {view === "list" ? (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Song</TableCell>
+                <TableCell>Grade</TableCell>
+                <TableCell>Diff</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {session.scores.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <img src={songs[s.song_id]?.img} alt="cover" width={40} />
+                      <Link to={`/song/${s.song_id}/${s.mode}/${s.diff}`}>{songs[s.song_id]?.title || s.song_id}</Link>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    {s.grade ? <img src={grades[s.grade]} alt={s.grade} height={30}/> : "-"}
+                  </TableCell>
+                  <TableCell>
+                    <DiffBall className={`${s.mode} ${s.diff}`} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            {session.scores.map((s) => (
+              <Paper key={s.id} sx={{ p: 2 }}>
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <img src={songs[s.song_id]?.img} alt="cover" width={40} />
                   <Link to={`/song/${s.song_id}/${s.mode}/${s.diff}`}>{songs[s.song_id]?.title || s.song_id}</Link>
                 </Box>
-              </TableCell>
-              <TableCell>
-                {s.grade ? <img src={grades[s.grade]} alt={s.grade} height={30} /> : "-"}
-              </TableCell>
-              <TableCell>
+                <Box sx={{ mt: 1 }}>
+                  {s.grade ? <img src={grades[s.grade]} alt={s.grade} height={30}/> : "-"}
+                </Box>
                 <DiffBall className={`${s.mode} ${s.diff}`} />
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Box>
-  );
+              </Paper>
+            ))}
+          </Box>
+        )}
+      </Box>
+    );
+
 };
 
 export default SessionPage;

--- a/Frontend/src/Pages/Sessions/index.jsx
+++ b/Frontend/src/Pages/Sessions/index.jsx
@@ -7,10 +7,6 @@ import {
   TableBody,
   TableRow,
   TableCell,
-  Box,
-  ToggleButton,
-  ToggleButtonGroup,
-  Paper,
 } from "@mui/material";
 import Section from "../../Components/Layout/Section";
 
@@ -19,7 +15,6 @@ const api = new ApiClient();
 const SessionsPage = () => {
   const { userId } = useParams();
   const [sessions, setSessions] = useState([]);
-  const [view, setView] = useState("list");
 
   useEffect(() => {
     api
@@ -33,50 +28,24 @@ const SessionsPage = () => {
 
   return (
     <Section header="Sessions">
-      <ToggleButtonGroup
-        value={view}
-        exclusive
-        onChange={(_, v) => v && setView(v)}
-        sx={{ mb: 2 }}
-      >
-        <ToggleButton value="list">List</ToggleButton>
-        <ToggleButton value="grid">Grid</ToggleButton>
-      </ToggleButtonGroup>
-      {view === "list" ? (
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Start</TableCell>
-              <TableCell>Duration</TableCell>
-              <TableCell>Scores</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {sessions.map((s) => (
-              <TableRow key={s.id} component={Link} to={`/session/${s.id}`}>
-                <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
-                <TableCell>{formatDuration(s)}m</TableCell>
-                <TableCell>{s._count?.scores || s.scores?.length || 0}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      ) : (
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Start</TableCell>
+            <TableCell>Duration</TableCell>
+            <TableCell>Scores</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
           {sessions.map((s) => (
-            <Paper
-              key={s.id}
-              component={Link}
-              to={`/session/${s.id}`}
-              sx={{ p: 2, textDecoration: "none" }}
-            >
-              <div>{new Date(s.startedAt).toLocaleString()}</div>
-              <div>{formatDuration(s)}m</div>
-              <div>{s._count?.scores || s.scores?.length || 0} scores</div>
-            </Paper>
+            <TableRow key={s.id} component={Link} to={`/session/${s.id}`}>
+              <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
+              <TableCell>{formatDuration(s)}m</TableCell>
+              <TableCell>{s._count?.scores || s.scores?.length || 0}</TableCell>
+            </TableRow>
           ))}
-        </Box>
-      )}
+        </TableBody>
+      </Table>
     </Section>
   );
 };

--- a/Server/src/controllers/sessions.controller.js
+++ b/Server/src/controllers/sessions.controller.js
@@ -1,5 +1,6 @@
 const catchAsync = require('../utils/catchAsync');
 const httpStatus = require('http-status');
+const ApiError = require('../utils/ApiError');
 const { sessionService } = require('../services');
 
 const getCurrent = catchAsync(async (req, res) => {
@@ -34,4 +35,18 @@ const getSession = catchAsync(async (req, res) => {
   res.send(session);
 });
 
-module.exports = { getCurrent, endSession, cancelSession, listSessions, getSession };
+const deleteSession = catchAsync(async (req, res) => {
+  const removed = await sessionService.deleteSession(req.params.id, req.user.id);
+  if (!removed) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Session not found');
+  }
+  res.status(httpStatus.NO_CONTENT).send();
+});
+module.exports = {
+  getCurrent,
+  endSession,
+  cancelSession,
+  listSessions,
+  getSession,
+  deleteSession,
+};

--- a/Server/src/routes/v1/sessions.route.js
+++ b/Server/src/routes/v1/sessions.route.js
@@ -11,5 +11,6 @@ router.post('/end', auth('postScores'), sessionsController.endSession);
 router.post('/cancel', auth('postScores'), sessionsController.cancelSession);
 router.get('/', auth('getScores'), sessionsController.listSessions);
 router.get('/:id', auth('getScores'), validate(sessionsValidation.getSession), sessionsController.getSession);
+router.delete('/:id', auth('postScores'), validate(sessionsValidation.deleteSession), sessionsController.deleteSession);
 
 module.exports = router;

--- a/Server/src/services/session.service.js
+++ b/Server/src/services/session.service.js
@@ -58,6 +58,14 @@ const cancelSession = async (userId) => {
   return null;
 };
 
+const deleteSession = async (id, userId) => {
+  const session = await prisma.session.findUnique({ where: { id: Number(id) } });
+  if (!session || session.userId !== userId) return null;
+  await prisma.score.updateMany({ where: { sessionId: session.id }, data: { sessionId: null } });
+  await prisma.session.delete({ where: { id: session.id } });
+  return session;
+};
+
 const listSessions = async (userId) =>
   prisma.session.findMany({
     where: { userId },
@@ -68,4 +76,12 @@ const listSessions = async (userId) =>
 const getSession = async (id) =>
   prisma.session.findUnique({ where: { id: Number(id) }, include: { scores: true } });
 
-module.exports = { handleScore, getCurrent, endSession, cancelSession, listSessions, getSession };
+module.exports = {
+  handleScore,
+  getCurrent,
+  endSession,
+  cancelSession,
+  listSessions,
+  getSession,
+  deleteSession,
+};

--- a/Server/src/validations/sessions.validation.js
+++ b/Server/src/validations/sessions.validation.js
@@ -12,4 +12,10 @@ const getSession = {
   }),
 };
 
-module.exports = { listSessions, getSession };
+const deleteSession = {
+  params: Joi.object().keys({
+    id: Joi.number().required(),
+  }),
+};
+
+module.exports = { listSessions, getSession, deleteSession };


### PR DESCRIPTION
## Summary
- remove grid/list toggle from sessions page
- add grid/list view toggle to individual session page
- allow owners to delete a session
- support delete session API endpoint

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in Server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ce231ce88324a939012e4d9138d3