### PR TITLE
Improve session grid layout

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -22,8 +22,15 @@ const api = new ApiClient();
 
 const DiffBall = styled.span`
   display: inline-block;
-  width: 30px;
-  height: 30px;
+  width: 20px;
+  height: 20px;
+`;
+
+const GradeImg = styled.img`
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 40px;
 `;
 
 const SessionPage = () => {
@@ -125,15 +132,25 @@ const SessionPage = () => {
         ) : (
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
             {session.scores.map((s) => (
-              <Paper key={s.id} sx={{ p: 2 }}>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <img src={songs[s.song_id]?.img} alt="cover" width={40} />
-                  <Link to={`/song/${s.song_id}/${s.mode}/${s.diff}`}>{songs[s.song_id]?.title || s.song_id}</Link>
+              <Paper key={s.id} sx={{ p: 2, width: 160 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 1,
+                    mb: 1,
+                  }}
+                >
+                  <DiffBall className={`${s.mode} ${s.diff}`} />
+                  <Link to={`/song/${s.song_id}/${s.mode}/${s.diff}`}>{
+                    songs[s.song_id]?.title || s.song_id
+                  }</Link>
                 </Box>
-                <Box sx={{ mt: 1 }}>
-                  {s.grade ? <img src={grades[s.grade]} alt={s.grade} height={30}/> : "-"}
+                <Box sx={{ position: "relative", textAlign: "center" }}>
+                  <img src={songs[s.song_id]?.img} alt="cover" width={120} />
+                  {s.grade && <GradeImg src={grades[s.grade]} alt={s.grade} />}
                 </Box>
-                <DiffBall className={`${s.mode} ${s.diff}`} />
               </Paper>
             ))}
           </Box>


### PR DESCRIPTION
## Summary
- adjust DiffBall size and add GradeImg for overlay
- rearrange session grid items with title on top
- enlarge song miniature and overlay grade icon

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d392e40c832490791c0b411310a0