### PR TITLE
Fix session banner refresh loop

### DIFF
--- a/Frontend/src/Components/SessionBanner.jsx
+++ b/Frontend/src/Components/SessionBanner.jsx
@@ -8,6 +8,9 @@ const api = new ApiClient();
 const SessionBanner = () => {
   const [sessionId, setSessionId] = useState(null);
   useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+
     const load = () => {
       api
         .getCurrentSession()


### PR DESCRIPTION
## Summary
- check auth token before polling current session

## Testing
- `npm test` in `Server` *(fails: jest not found)*
- `npm test` in `Frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878eed65ef4832490d2aa95f4a6aaea