### PR TITLE
Add sessions overview to Scores page

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -58,6 +58,8 @@ export class ApiClient {
     endSession = () => client.post('sessions/end')
     cancelSession = () => client.post('sessions/cancel')
     listSessions = (userId) => client.get('sessions', { params: userId ? { userId } : {} })
+    getOngoingSessions = (limit) => client.get('sessions/ongoing', { params: { limit } })
+    getAllSessions = (limit) => client.get('sessions/all', { params: { limit } })
     getSession = (id) => client.get(`sessions/${id}`)
     deleteSession = (id) => client.delete(`sessions/${id}`)
 }

--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -13,11 +13,21 @@ const apiClient = new ApiClient();
 const Scores = () => {
   const [latest, setLatest] = useState([]);
   const [latestPlayers, setLatestPlayers] = useState([]);
+  const [ongoingSessions, setOngoingSessions] = useState([]);
+  const [allSessions, setAllSessions] = useState([]);
 
   useEffect(() => {
     apiClient.getLatestScores().then((res) => setLatest(res.data)).catch(() => {});
     apiClient.getLatestPlayers()
       .then((res) => setLatestPlayers(res.data))
+      .catch(() => {});
+    apiClient
+      .getOngoingSessions()
+      .then((res) => setOngoingSessions(res.data))
+      .catch(() => {});
+    apiClient
+      .getAllSessions()
+      .then((res) => setAllSessions(res.data))
       .catch(() => {});
   }, []);
 
@@ -90,6 +100,68 @@ const Scores = () => {
           </TableBody>
         </Table>
       </Section>
+      {ongoingSessions.length > 0 && (
+        <Section header="Current sessions">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>User</TableCell>
+                <TableCell>Play count</TableCell>
+                <TableCell>Duration</TableCell>
+                <TableCell>Start</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {ongoingSessions.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Avatar src={s.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                      <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                    </Box>
+                  </TableCell>
+                  <TableCell>{s._count?.scores || 0}</TableCell>
+                  <TableCell>
+                    {Math.round((new Date(s.endedAt || s.lastScore) - new Date(s.startedAt)) / 60000)}m
+                  </TableCell>
+                  <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Section>
+      )}
+      {allSessions.length > 0 && (
+        <Section header="All sessions">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>User</TableCell>
+                <TableCell>Play count</TableCell>
+                <TableCell>Duration</TableCell>
+                <TableCell>Start</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {allSessions.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Avatar src={s.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                      <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                    </Box>
+                  </TableCell>
+                  <TableCell>{s._count?.scores || 0}</TableCell>
+                  <TableCell>
+                    {Math.round((new Date(s.endedAt || s.lastScore) - new Date(s.startedAt)) / 60000)}m
+                  </TableCell>
+                  <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Section>
+      )}
     </>
   );
 };

--- a/Server/src/controllers/sessions.controller.js
+++ b/Server/src/controllers/sessions.controller.js
@@ -21,6 +21,18 @@ const cancelSession = catchAsync(async (req, res) => {
   res.status(httpStatus.NO_CONTENT).send();
 });
 
+const listOngoingSessions = catchAsync(async (req, res) => {
+  const limit = req.query.limit ? Number(req.query.limit) : undefined;
+  const sessions = await sessionService.listOngoingSessions(limit);
+  res.send(sessions);
+});
+
+const listAllSessions = catchAsync(async (req, res) => {
+  const limit = req.query.limit ? Number(req.query.limit) : undefined;
+  const sessions = await sessionService.listAllSessions(limit);
+  res.send(sessions);
+});
+
 const listSessions = catchAsync(async (req, res) => {
   const userId = req.query.userId || req.user.id;
   const sessions = await sessionService.listSessions(userId);
@@ -46,6 +58,8 @@ module.exports = {
   getCurrent,
   endSession,
   cancelSession,
+  listOngoingSessions,
+  listAllSessions,
   listSessions,
   getSession,
   deleteSession,

--- a/Server/src/routes/v1/sessions.route.js
+++ b/Server/src/routes/v1/sessions.route.js
@@ -9,6 +9,18 @@ const router = express.Router();
 router.get('/current', auth('getScores'), sessionsController.getCurrent);
 router.post('/end', auth('postScores'), sessionsController.endSession);
 router.post('/cancel', auth('postScores'), sessionsController.cancelSession);
+router.get(
+  '/ongoing',
+  auth('getScores'),
+  validate(sessionsValidation.listOngoingSessions),
+  sessionsController.listOngoingSessions,
+);
+router.get(
+  '/all',
+  auth('getScores'),
+  validate(sessionsValidation.listAllSessions),
+  sessionsController.listAllSessions,
+);
 router.get('/', auth('getScores'), sessionsController.listSessions);
 router.get('/:id', auth('getScores'), validate(sessionsValidation.getSession), sessionsController.getSession);
 router.delete('/:id', auth('postScores'), validate(sessionsValidation.deleteSession), sessionsController.deleteSession);

--- a/Server/src/services/session.service.js
+++ b/Server/src/services/session.service.js
@@ -73,6 +73,27 @@ const listSessions = async (userId) =>
     include: { _count: { select: { scores: true } } },
   });
 
+const listOngoingSessions = async (limit = 10) =>
+  prisma.session.findMany({
+    where: { endedAt: null },
+    orderBy: { id: 'desc' },
+    take: limit,
+    include: {
+      user: { select: { username: true, avatarUrl: true } },
+      _count: { select: { scores: true } },
+    },
+  });
+
+const listAllSessions = async (limit = 10) =>
+  prisma.session.findMany({
+    take: limit,
+    orderBy: { id: 'desc' },
+    include: {
+      user: { select: { username: true, avatarUrl: true } },
+      _count: { select: { scores: true } },
+    },
+  });
+
 const getSession = async (id) =>
   prisma.session.findUnique({ where: { id: Number(id) }, include: { scores: true } });
 
@@ -82,6 +103,8 @@ module.exports = {
   endSession,
   cancelSession,
   listSessions,
+  listOngoingSessions,
+  listAllSessions,
   getSession,
   deleteSession,
 };

--- a/Server/src/validations/sessions.validation.js
+++ b/Server/src/validations/sessions.validation.js
@@ -6,6 +6,18 @@ const listSessions = {
   }),
 };
 
+const listOngoingSessions = {
+  query: Joi.object().keys({
+    limit: Joi.number().integer(),
+  }),
+};
+
+const listAllSessions = {
+  query: Joi.object().keys({
+    limit: Joi.number().integer(),
+  }),
+};
+
 const getSession = {
   params: Joi.object().keys({
     id: Joi.number().required(),
@@ -18,4 +30,10 @@ const deleteSession = {
   }),
 };
 
-module.exports = { listSessions, getSession, deleteSession };
+module.exports = {
+  listSessions,
+  listOngoingSessions,
+  listAllSessions,
+  getSession,
+  deleteSession,
+};


### PR DESCRIPTION
## Summary
- fetch ongoing and all sessions from new API endpoints
- render Current and All sessions tables on Scores page
- expose `getOngoingSessions` and `getAllSessions` from API client
- implement backend routes and services for listing sessions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f52350608324b348150a1eaeed56