### PR TITLE
Display first pass badge for scores

### DIFF
--- a/Frontend/src/Pages/Scores/All.jsx
+++ b/Frontend/src/Pages/Scores/All.jsx
@@ -20,6 +20,7 @@ import {
   Avatar,
   Box,
   TableSortLabel,
+  Chip,
 } from '@mui/material';
 import GradeDropdown from '../../Components/GradeDropdown';
 import Av from '../../Assets/anon.png';
@@ -230,7 +231,16 @@ const AllScores = () => {
                   <DiffBall className={`${s.mode} ${s.diff}`} />
                 </TableCell>
                 <TableCell>
-                  {s.grade ? <GradeIcon src={grades[s.grade]} alt={s.grade} /> : '-'}
+                  {s.grade ? (
+                    <>
+                      <GradeIcon src={grades[s.grade]} alt={s.grade} />
+                      {s.firstPass && (
+                        <Chip label="New" color="success" size="small" sx={{ ml: 1 }} />
+                      )}
+                    </>
+                  ) : (
+                    '-'
+                  )}
                 </TableCell>
                 <TableCell>{new Date(s.createdAt).toLocaleString()}</TableCell>
               </TableRow>

--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -13,6 +13,7 @@ import {
   TableRow,
   Avatar,
   Box,
+  Chip,
 } from "@mui/material";
 import Av from "../../Assets/anon.png";
 
@@ -131,7 +132,12 @@ const Scores = () => {
                 </TableCell>
                 <TableCell>
                   {s.grade ? (
-                    <GradeIcon src={grades[s.grade]} alt={s.grade} />
+                    <>
+                      <GradeIcon src={grades[s.grade]} alt={s.grade} />
+                      {s.firstPass && (
+                        <Chip label="New" color="success" size="small" sx={{ ml: 1 }} />
+                      )}
+                    </>
                   ) : (
                     "-"
                   )}

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -13,6 +13,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Chip,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ClearIcon from "@mui/icons-material/Clear";
@@ -187,7 +188,12 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
                       <TableRow key={h.id}>
                         <TableCell>
                           {h.grade ? (
-                            <GradeIcon src={grades[h.grade]} alt={h.grade} />
+                            <>
+                              <GradeIcon src={grades[h.grade]} alt={h.grade} />
+                              {h.firstPass && (
+                                <Chip label="New" color="success" size="small" sx={{ ml: 1 }} />
+                              )}
+                            </>
                           ) : (
                             "-"
                           )}


### PR DESCRIPTION
## Summary
- show chip for scores with `firstPass` flag in latest scores list
- indicate first pass in "All Scores" table
- display first pass in song play history

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in Server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ffb649c08324b10056f36b1c9f55