### PR TITLE
Add sessions overview page

### DIFF
--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -22,7 +22,7 @@ const Scores = () => {
   const [latest, setLatest] = useState([]);
   const [latestPlayers, setLatestPlayers] = useState([]);
   const [ongoingSessions, setOngoingSessions] = useState([]);
-  const [allSessions, setAllSessions] = useState([]);
+  const [latestSessions, setLatestSessions] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -40,7 +40,7 @@ const Scores = () => {
       .catch(() => {});
     apiClient
       .getAllSessions()
-      .then((res) => setAllSessions(res.data))
+      .then((res) => setLatestSessions(res.data))
       .catch(() => {});
   }, []);
 
@@ -95,6 +95,9 @@ const Scores = () => {
               ))}
             </TableBody>
           </Table>
+          <p>
+            <Link to="/SessionsAll">See all sessions</Link>
+          </p>
         </Section>
       )}
       <Section header="Latest scores">
@@ -146,8 +149,8 @@ const Scores = () => {
           <Link to="/ScoresAll">See all scores</Link>
         </p>
       </Section>
-      {allSessions.length > 0 && (
-        <Section header="All sessions">
+      {latestSessions.length > 0 && (
+        <Section header="Latest sessions">
           <Table size="small">
             <TableHead>
               <TableRow>
@@ -158,7 +161,7 @@ const Scores = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {allSessions.map((s) => (
+              {latestSessions.map((s) => (
                 <TableRow
                   key={s.id}
                   hover
@@ -195,6 +198,9 @@ const Scores = () => {
               ))}
             </TableBody>
           </Table>
+          <p>
+            <Link to="/SessionsAll">See all sessions</Link>
+          </p>
         </Section>
       )}
 

--- a/Frontend/src/Pages/Sessions/All.jsx
+++ b/Frontend/src/Pages/Sessions/All.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import Section from "../../Components/Layout/Section";
+import { ApiClient } from "../../API/httpService";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Avatar,
+  Box,
+} from "@mui/material";
+import Av from "../../Assets/anon.png";
+
+const api = new ApiClient();
+
+const AllSessions = () => {
+  const [sessions, setSessions] = useState([]);
+
+  useEffect(() => {
+    api
+      .getAllSessions()
+      .then((r) => setSessions(r.data))
+      .catch(() => {});
+  }, []);
+
+  const formatDuration = (s) =>
+    Math.round((new Date(s.endedAt || s.lastScore) - new Date(s.startedAt)) / 60000);
+
+  return (
+    <Section header="All sessions">
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>User</TableCell>
+            <TableCell>Play count</TableCell>
+            <TableCell>Duration</TableCell>
+            <TableCell>Start</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sessions.map((s) => (
+            <TableRow key={s.id} component={Link} to={`/session/${s.id}`}>
+              <TableCell>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Avatar src={s.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
+                  <UserLink to={`/profile/${s.userId}`}>{s.user?.username}</UserLink>
+                </Box>
+              </TableCell>
+              <TableCell>{s._count?.scores || 0}</TableCell>
+              <TableCell>{formatDuration(s)}m</TableCell>
+              <TableCell>{new Date(s.startedAt).toLocaleString()}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Section>
+  );
+};
+
+export default AllSessions;
+
+const UserLink = styled(Link)`
+  color: inherit;
+  text-decoration: underline;
+  font-weight: bold;
+`;

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -12,6 +12,7 @@ import Leaderboard from '../Pages/Leaderboard'
 import Titles from '../Pages/Titles'
 import SessionPage from '../Pages/Session'
 import SessionsPage from '../Pages/Sessions'
+import AllSessions from '../Pages/Sessions/All'
 // import { useDispatch, useSelector } from 'react-redux'
 import Login from '../Pages/Login'
 import Profile from '../Pages/Profile'
@@ -44,6 +45,10 @@ const router = createHashRouter([
             {
                 path: 'ScoresAll',
                 element: <AllScores />
+            },
+            {
+                path: 'SessionsAll',
+                element: <AllSessions />
             },
             {
                 path: 'session',


### PR DESCRIPTION
## Summary
- show latest sessions on Scores page instead of All sessions
- provide See all sessions link
- create SessionsAll page and route

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in Server *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687900a022dc8324818058340238f22a