### PR TITLE
Fix share session table text color

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -247,7 +247,15 @@ const SessionPage = () => {
           </Box>
         )}
         <Box
-          sx={{ position: 'absolute', left: -9999, top: 0, p: 2, bgcolor: '#111', color: '#fff' }}
+          sx={{
+            position: 'absolute',
+            left: -9999,
+            top: 0,
+            p: 2,
+            bgcolor: '#111',
+            color: '#fff',
+            '& .MuiTableCell-root': { color: '#fff' },
+          }}
           ref={shareRef}
         >
           {view === 'list'


### PR DESCRIPTION
## Summary
- ensure list view share screenshot uses white table text

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879027df4b88324a8512cdbe87eab26