### PR TITLE
Expand search sections automatically

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -133,6 +133,7 @@ const Songs = ({ mode }) => {
     const stored = localStorage.getItem("favorites");
     return stored ? JSON.parse(stored) : {};
   });
+  const [expandedDiffs, setExpandedDiffs] = useState({});
 
   useEffect(() => {
     localStorage.setItem("hiddenDiffs", JSON.stringify(hiddenDiffs));
@@ -145,6 +146,18 @@ const Songs = ({ mode }) => {
   useEffect(() => {
     localStorage.setItem("songSort", sort);
   }, [sort]);
+
+  useEffect(() => {
+    if (search?.title && search.title.length > 5) {
+      const newExpanded = {};
+      Object.keys(diffCounter[mode]).forEach((d) => {
+        newExpanded[d] = true;
+      });
+      setExpandedDiffs(newExpanded);
+    } else if (!search?.title) {
+      setExpandedDiffs({});
+    }
+  }, [search?.title, mode]);
 
   const maxDiff = Math.max(
     ...Object.keys(diffCounter[mode]).map((d) => parseInt(d.replace("lv_", "")))
@@ -572,8 +585,14 @@ const Songs = ({ mode }) => {
         {Object.entries(diffCounter[mode]).map(([diff, count]) => {
           prevCategory = undefined;
           return (
-            shouldDisplayDiff(diff) && (
-              <Accordion key={diff}>
+              shouldDisplayDiff(diff) && (
+                <Accordion
+                  key={diff}
+                  expanded={expandedDiffs[diff] || false}
+                  onChange={(_, exp) =>
+                    setExpandedDiffs({ ...expandedDiffs, [diff]: exp })
+                  }
+                >
                 <AccordionSummary
                   expandIcon={<ExpandMoreIcon />}
                   aria-controls={`panel${diff}-content`}


### PR DESCRIPTION
## Summary
- auto-expand all song sections if search by name has >5 characters
- collapse all sections when clearing the search

## Testing
- `npm test -- -w=1 --runInBand` *(fails: react-scripts not found)*
- `npm test` in `Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687902d714048324af73ae471729b4e5