### PR TITLE
Fix grid share width

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -262,6 +262,7 @@ const SessionPage = () => {
             bgcolor: '#111',
             color: '#fff',
             '& .MuiTableCell-root': { color: '#fff' },
+            width: view === 'grid' ? 512 : 'auto',
           }}
           ref={shareRef}
         >


### PR DESCRIPTION
## Summary
- constrain width of generated grid share image

## Testing
- `CI=1 npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879043d9fa08324bfded37a5f66aac5