### PR TITLE
Fix spacing on share grid card

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -367,7 +367,7 @@ const SessionPage = () => {
                     height: 200,
                     display: "flex",
                     flexDirection: "column",
-                    justifyContent: "space-between",
+                    justifyContent: "flex-start",
                   }}
                 >
                   <Box


### PR DESCRIPTION
## Summary
- fix share image grid card layout so titles sit closer to cover images

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879110b6124832481cc4b43a2350553