### PR TITLE
Show pass status in shared session screenshots

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -343,7 +343,12 @@ const SessionPage = () => {
                     </TableCell>
                     <TableCell>
                       {s.grade ? (
-                        <img src={grades[s.grade]} alt={s.grade} height={30} />
+                        <>
+                          <img src={grades[s.grade]} alt={s.grade} height={30} />
+                          {s.firstPass && (
+                            <Chip label="New" color="success" size="small" sx={{ ml: 1 }} />
+                          )}
+                        </>
                       ) : (
                         "-"
                       )}
@@ -393,7 +398,17 @@ const SessionPage = () => {
                       crossOrigin="anonymous"
                     />
                     {s.grade && (
-                      <GradeImg src={grades[s.grade]} alt={s.grade} />
+                      <>
+                        <GradeImg src={grades[s.grade]} alt={s.grade} />
+                        {s.firstPass && (
+                          <Chip
+                            label="New"
+                            color="success"
+                            size="small"
+                            sx={{ position: "absolute", top: 0, left: 0 }}
+                          />
+                        )}
+                      </>
                     )}
                   </Box>
                 </Paper>


### PR DESCRIPTION
## Summary
- show `New` badge for first passes in shareable session images

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm test --silent` in Frontend *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879184de7c4832483bd355ad164b7a6