### PR TITLE
Allow public sessions data

### DIFF
--- a/Frontend/src/Pages/Scores/index.jsx
+++ b/Frontend/src/Pages/Scores/index.jsx
@@ -25,7 +25,6 @@ const Scores = () => {
   const [ongoingSessions, setOngoingSessions] = useState([]);
   const [latestSessions, setLatestSessions] = useState([]);
   const navigate = useNavigate();
-  const loggedIn = Boolean(localStorage.getItem('token'));
 
   useEffect(() => {
     apiClient
@@ -36,16 +35,14 @@ const Scores = () => {
       .getLatestPlayers()
       .then((res) => setLatestPlayers(res.data))
       .catch(() => {});
-    if (loggedIn) {
-      apiClient
-        .getOngoingSessions()
-        .then((res) => setOngoingSessions(res.data))
-        .catch(() => {});
-      apiClient
-        .getAllSessions()
-        .then((res) => setLatestSessions(res.data))
-        .catch(() => {});
-    }
+    apiClient
+      .getOngoingSessions()
+      .then((res) => setOngoingSessions(res.data))
+      .catch(() => {});
+    apiClient
+      .getAllSessions()
+      .then((res) => setLatestSessions(res.data))
+      .catch(() => {});
   }, []);
 
   return (

--- a/Server/src/routes/v1/sessions.route.js
+++ b/Server/src/routes/v1/sessions.route.js
@@ -11,18 +11,16 @@ router.post('/end', auth('postScores'), sessionsController.endSession);
 router.post('/cancel', auth('postScores'), sessionsController.cancelSession);
 router.get(
   '/ongoing',
-  auth('getScores'),
   validate(sessionsValidation.listOngoingSessions),
   sessionsController.listOngoingSessions,
 );
 router.get(
   '/all',
-  auth('getScores'),
   validate(sessionsValidation.listAllSessions),
   sessionsController.listAllSessions,
 );
 router.get('/', auth('getScores'), sessionsController.listSessions);
-router.get('/:id', auth('getScores'), validate(sessionsValidation.getSession), sessionsController.getSession);
+router.get('/:id', validate(sessionsValidation.getSession), sessionsController.getSession);
 router.delete('/:id', auth('postScores'), validate(sessionsValidation.deleteSession), sessionsController.deleteSession);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose session listing endpoints without auth
- always fetch sessions on scores page so unlogged users can see sessions

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn test` in frontend *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68791dbaad3c8324bd62e77af838f5fe