### PR TITLE
Fix song details modal scrolling

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -705,6 +705,8 @@ const StyledBox = styled(Box)`
   left: 50%;
   transform: translate(-50%, -50%);
   width: 70%;
+  max-height: 90vh;
+  overflow-y: auto;
   background: white;
   boxshadow: 24;
   padding: 14px;


### PR DESCRIPTION
## Summary
- allow vertical scrolling on Song Details modal so all content is accessible on mobile

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm test -- -w` in Frontend *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687978e6ff5483249efd91aacd61aa3e