### PR TITLE
Enable dark mode toggle

### DIFF
--- a/Frontend/src/Components/Layout/index.jsx
+++ b/Frontend/src/Components/Layout/index.jsx
@@ -35,8 +35,13 @@ const themeDark = createTheme({
     },
   },
 });
+const getInitialMode = () => {
+  const saved = localStorage.getItem("mode");
+  return saved === "dark" ? "dark" : "light";
+};
+
 const Layout = () => {
-  const [mode, setMode] = React.useState("light");
+  const [mode, setMode] = React.useState(getInitialMode);
   const theme = useTheme();
   const colorMode = React.useMemo(
     () => ({
@@ -46,6 +51,10 @@ const Layout = () => {
     }),
     []
   );
+
+  React.useEffect(() => {
+    localStorage.setItem("mode", mode);
+  }, [mode]);
 
   return (
     <ColorModeContext.Provider value={colorMode}>

--- a/Frontend/src/Components/Navigation/index.jsx
+++ b/Frontend/src/Components/Navigation/index.jsx
@@ -222,6 +222,19 @@ function NavBar() {
                 <Typography textAlign="center">Log In</Typography>
               </MenuItem>
             )}
+            <Tooltip title="Toggle dark mode">
+              <IconButton
+                sx={{ ml: 1 }}
+                onClick={colorMode.toggleColorMode}
+                color="inherit"
+              >
+                {theme.palette.mode === "dark" ? (
+                  <Brightness7Icon />
+                ) : (
+                  <Brightness4Icon />
+                )}
+              </IconButton>
+            </Tooltip>
           </Toolbar>
         </Container>
       </AppBar>


### PR DESCRIPTION
## Summary
- store selected light/dark mode in localStorage
- add toggle icon to the navigation bar

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687978d08eac8324bbe1004c4d063964