### PR TITLE
Add grade dropdown when submitting accurate score

### DIFF
--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -109,7 +109,7 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
           </Typography>
         )}
         <Divider sx={{ my: 2 }} />
-        {loggedIn && (
+        {loggedIn && !showAccurate && (
           <GradeWrapper>
             <GradeSelect
               label="Set Grade"
@@ -133,6 +133,11 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
         )}
         {showAccurate && (
           <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            <GradeSelect
+              label="Set Grade"
+              value={grade}
+              onChange={(g) => setGrade(g)}
+            />
             <TextField label="Perfects" size="small" type="number" value={perf} onChange={(e) => setPerf(e.target.value)} />
             <TextField label="Greats" size="small" type="number" value={great} onChange={(e) => setGreat(e.target.value)} />
             <TextField label="Good" size="small" type="number" value={good} onChange={(e) => setGood(e.target.value)} />
@@ -159,7 +164,7 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
                 })
                   .then(() => {
                     setShowAccurate(false);
-                    changeGrade && changeGrade(grade);
+                    changeGrade && changeGrade(grade, true);
                   });
               }}
             >

--- a/Frontend/src/Pages/Songs/SongPage.jsx
+++ b/Frontend/src/Pages/Songs/SongPage.jsx
@@ -37,16 +37,17 @@ const SongPage = () => {
     api.getBestScore(mode, id, diff).then((r) => setBestScore(r.data));
   }, [id, diff, mode, favorites]);
 
-  const changeGrade = (value) => {
+  const changeGrade = (value, skipPost = false) => {
     const api = new ApiClient();
-    api
-      .postScores(mode, { song_id: id, diff, grade: value })
-      .then((r) => {
-        const { session } = r.data || {};
-        if (session) storeSessionId(session.id);
-        setChart((c) => (c ? { ...c, grade: value } : c));
-        api.getScoreHistory(mode, id, diff).then((res) => setHistory(res.data));
-      });
+    const post = skipPost
+      ? Promise.resolve({ data: {} })
+      : api.postScores(mode, { song_id: id, diff, grade: value });
+    post.then((r) => {
+      const { session } = r.data || {};
+      if (session) storeSessionId(session.id);
+      setChart((c) => (c ? { ...c, grade: value } : c));
+      api.getScoreHistory(mode, id, diff).then((res) => setHistory(res.data));
+    });
   };
 
   const toggleFavorite = () => {

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -242,14 +242,15 @@ const Songs = ({ mode }) => {
     }
   };
 
-  const changeGrade = (value) => {
-    apiClient
-      .postScores(mode, {
-        song_id: openChart.id,
-        diff: openChart.diff,
-        grade: value,
-      })
-      .then((r) => {
+  const changeGrade = (value, skipPost = false) => {
+    const post = skipPost
+      ? Promise.resolve({ data: {} })
+      : apiClient.postScores(mode, {
+          song_id: openChart.id,
+          diff: openChart.diff,
+          grade: value,
+        });
+    post.then((r) => {
         const { newBadges = [], newTitles = [], isNew, session } = r.data || {};
         if (session) storeSessionId(session.id);
         if (isNew) {


### PR DESCRIPTION
## Summary
- hide grade selection when the accurate score form is open
- include a grade dropdown inside the accurate score form
- avoid posting the grade twice by skipping the POST call when full data is already sent

## Testing
- `npm test --prefix Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879fd22fbc483249c684f5d38d58007