### PR TITLE
Enable score detail view

### DIFF
--- a/Frontend/src/Components/ScoreDetailsDialog.jsx
+++ b/Frontend/src/Components/ScoreDetailsDialog.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '@mui/material';
+
+const ScoreDetailsDialog = ({ open, onClose, score }) => {
+  if (!score) return null;
+  const row = (label, value) => (
+    <TableRow>
+      <TableCell>{label}</TableCell>
+      <TableCell>{value ?? '-'}</TableCell>
+    </TableRow>
+  );
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Score Details</DialogTitle>
+      <DialogContent>
+        <Table size="small">
+          <TableBody>
+            {row('Grade', score.grade || '-')}
+            {row('Total', score.total)}
+            {row('Perfects', score.perfects)}
+            {row('Greats', score.greats)}
+            {row('Good', score.good)}
+            {row('Bad', score.bad)}
+            {row('Misses', score.misses)}
+            {row('Max Combo', score.combo)}
+          </TableBody>
+        </Table>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ScoreDetailsDialog;

--- a/Frontend/src/Pages/Scores/All.jsx
+++ b/Frontend/src/Pages/Scores/All.jsx
@@ -24,6 +24,7 @@ import {
 } from '@mui/material';
 import GradeDropdown from '../../Components/GradeDropdown';
 import Av from '../../Assets/anon.png';
+import ScoreDetailsDialog from '../../Components/ScoreDetailsDialog';
 
 
 const apiClient = new ApiClient();
@@ -42,6 +43,7 @@ const AllScores = () => {
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
   const [sort, setSort] = useState('createdAt:desc');
+  const [openScore, setOpenScore] = useState(null);
   const rowsPerPage = 30;
 
   const songsOptions = useMemo(
@@ -215,7 +217,12 @@ const AllScores = () => {
           </TableHead>
           <TableBody>
             {scores.map((s) => (
-              <TableRow key={s.id}>
+              <TableRow
+                key={s.id}
+                hover
+                sx={{ cursor: 'pointer' }}
+                onClick={() => setOpenScore(s)}
+              >
                 <TableCell>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <Avatar src={s.user?.avatarUrl || Av} sx={{ width: 24, height: 24 }} />
@@ -254,6 +261,11 @@ const AllScores = () => {
           onPageChange={(e, p) => setPage(p)}
           rowsPerPage={rowsPerPage}
           rowsPerPageOptions={[rowsPerPage]}
+        />
+        <ScoreDetailsDialog
+          open={!!openScore}
+          score={openScore}
+          onClose={() => setOpenScore(null)}
         />
       </Section>
     </>

--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -23,6 +23,7 @@ import { useUser } from "../../Components/User";
 import styled from "styled-components";
 import { storeSessionId } from "../../helpers/sessionUtils";
 import Logo from "../../Assets/logoSq.png";
+import ScoreDetailsDialog from "../../Components/ScoreDetailsDialog";
 
 const api = new ApiClient();
 
@@ -84,6 +85,7 @@ const SessionPage = () => {
   const [session, setSession] = useState(null);
   const [view, setView] = useState("list");
   const [selected, setSelected] = useState(new Set());
+  const [openScore, setOpenScore] = useState(null);
   const shareRef = useRef(null);
   const navigate = useNavigate();
   const { user } = useUser();
@@ -209,7 +211,12 @@ const SessionPage = () => {
           </TableHead>
           <TableBody>
             {session.scores.map((s) => (
-              <TableRow key={s.id}>
+              <TableRow
+                key={s.id}
+                hover
+                sx={{ cursor: 'pointer' }}
+                onClick={() => setOpenScore(s)}
+              >
                 <TableCell padding="checkbox">
                   <Checkbox
                     checked={selected.has(s.id)}
@@ -265,6 +272,7 @@ const SessionPage = () => {
                 onChange={() => toggleSelect(s.id)}
               />
               <Paper
+                onClick={() => setOpenScore(s)}
                 sx={{
                   p: 2,
                   width: 160,
@@ -272,6 +280,7 @@ const SessionPage = () => {
                   display: "flex",
                   flexDirection: "column",
                   justifyContent: "space-between",
+                  cursor: "pointer",
                 }}
               >
                 <Box
@@ -437,6 +446,11 @@ const SessionPage = () => {
           <img src={Logo} alt="logo" height={20} crossOrigin="anonymous" />
           {new Date(session.startedAt).toLocaleDateString()} - Trackitup.pl
         </Box>
+        <ScoreDetailsDialog
+          open={!!openScore}
+          score={openScore}
+          onClose={() => setOpenScore(null)}
+        />
       </Box>
     </Box>
   );

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -27,6 +27,7 @@ import styled from "styled-components";
 import GradeSelect from "../../Components/GradeSelect";
 import packs from "../../consts/packs";
 import { ApiClient } from "../../API/httpService";
+import ScoreDetailsDialog from "../../Components/ScoreDetailsDialog";
 
 const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history = [], removeScore, rivalScores = [], bestScore }) => {
   const [grade, setGrade] = useState(chart.grade || "");
@@ -34,6 +35,7 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
   const [ratings, setRatings] = useState({ harder: 0, ok: 0, easier: 0 });
   const [goal, setGoal] = useState(false);
   const [showAccurate, setShowAccurate] = useState(false);
+  const [openScore, setOpenScore] = useState(null);
   const [perf, setPerf] = useState(0);
   const [great, setGreat] = useState(0);
   const [good, setGood] = useState(0);
@@ -279,7 +281,12 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
                   </TableHead>
                   <TableBody>
                     {history.map((h) => (
-                      <TableRow key={h.id}>
+                      <TableRow
+                        key={h.id}
+                        hover
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => setOpenScore(h)}
+                      >
                         <TableCell>
                           {h.grade ? (
                             <>
@@ -311,6 +318,11 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
           </>
         )}
       </Content>
+      <ScoreDetailsDialog
+        open={!!openScore}
+        score={openScore}
+        onClose={() => setOpenScore(null)}
+      />
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
- add new `ScoreDetailsDialog` component
- show detailed score data from score tables
- enable opening details from play history, all scores, and session views

## Testing
- `npm test --prefix Frontend` *(fails: react-scripts not found)*
- `npm test --prefix Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ff51430c8324a64cfa7de4782557