### PR TITLE
Expand play history on song page

### DIFF
--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -28,7 +28,17 @@ import GradeSelect from "../../Components/GradeSelect";
 import packs from "../../consts/packs";
 import { ApiClient } from "../../API/httpService";
 
-const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history = [], removeScore, rivalScores = [], bestScore }) => {
+const SongDetails = ({
+  chart,
+  changeGrade,
+  toggleFavorite,
+  changeDiff,
+  history = [],
+  removeScore,
+  rivalScores = [],
+  bestScore,
+  playHistoryExpanded = false,
+}) => {
   const [grade, setGrade] = useState(chart.grade || "");
   const loggedIn = Boolean(localStorage.getItem("token"));
   const [ratings, setRatings] = useState({ harder: 0, ok: 0, easier: 0 });
@@ -264,7 +274,7 @@ const SongDetails = ({ chart, changeGrade, toggleFavorite, changeDiff, history =
         {history.length > 0 && (
           <>
             <Divider sx={{ my: 2 }} />
-            <Accordion>
+            <Accordion defaultExpanded={playHistoryExpanded}>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography>Play History</Typography>
               </AccordionSummary>

--- a/Frontend/src/Pages/Songs/SongPage.jsx
+++ b/Frontend/src/Pages/Songs/SongPage.jsx
@@ -90,6 +90,7 @@ const SongPage = () => {
         rivalScores={rivalScores}
         bestScore={bestScore}
         removeScore={removeScore}
+        playHistoryExpanded
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- keep play history accordion open when SongDetails is used on its own page

## Testing
- `npm test` (fails: `react-scripts: not found`)
- `npm test` in `Server` (fails: `jest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_6879ff35b8608324853f7d427e0caadb