### PR TITLE
Fix dark mode styling for song details dialog

### DIFF
--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -752,8 +752,9 @@ const StyledBox = styled(Box)`
   width: 70%;
   max-height: 90vh;
   overflow-y: auto;
-  background: white;
-  boxshadow: 24;
+  background: ${({ theme }) =>
+    theme.palette?.background.paper || "white"};
+  box-shadow: ${({ theme }) => theme.shadows?.[5] || 0};
   padding: 14px;
 `;
 


### PR DESCRIPTION
## Summary
- use the theme's paper background in the SongDetails popup
- add proper box shadow styling

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a02110ba48324aab4ad8ca0d4eb17