### PR TITLE
Add OCR upload flow

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -72,6 +72,14 @@ export class ApiClient {
     postRival = (rivalId) => client.post('rivals', { rivalId })
     getRivalScores = (mode, songId, diff, userId) =>
         client.get(`rivals/scores/${mode}/${songId}/${diff}`, { params: userId ? { userId } : {} })
+
+    ocrScore = (file) => {
+        const data = new FormData()
+        data.append('scoreImage', file)
+        return client.post('scores/ocr', data, {
+            headers: { 'Content-Type': 'multipart/form-data' }
+        })
+    }
 }
 
 export default client

--- a/Frontend/src/Components/Navigation/index.jsx
+++ b/Frontend/src/Components/Navigation/index.jsx
@@ -36,7 +36,7 @@ const pages = [
   "Coop",
   "Scores",
   "Leaderboard",
-  // "Add Score",
+  "Add Score",
 ];
 const settings = ["Profile", "Logout"];
 
@@ -62,7 +62,11 @@ function NavBar() {
 
   const handleCloseNavMenu = (page) => {
     if (page) {
-      navigate(`/${page}`);
+      if (page === "Add Score") {
+        navigate("/add");
+      } else {
+        navigate(`/${page}`);
+      }
     }
     setAnchorElNav(null);
   };

--- a/Frontend/src/Pages/AddScore/index.jsx
+++ b/Frontend/src/Pages/AddScore/index.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import Section from "../../Components/Layout/Section";
+import { ApiClient } from "../../API/httpService";
+import { Button, Box } from "@mui/material";
+
+const apiClient = new ApiClient();
+
+const AddScore = () => {
+  const [file, setFile] = useState(null);
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleUpload = () => {
+    if (!file) return;
+    setLoading(true);
+    apiClient
+      .ocrScore(file)
+      .then((res) => setResult(res.data))
+      .catch(() => setResult(null))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <Section header="Add Score">
+      <input
+        type="file"
+        accept="image/*"
+        onChange={(e) => setFile(e.target.files[0])}
+      />
+      <Button variant="contained" disabled={!file || loading} onClick={handleUpload}>
+        Upload
+      </Button>
+      {result && (
+        <Box component="pre" sx={{ whiteSpace: "pre-wrap" }}>
+          {JSON.stringify(result, null, 2)}
+        </Box>
+      )}
+    </Section>
+  );
+};
+
+export default AddScore;

--- a/Frontend/src/Routing/index.jsx
+++ b/Frontend/src/Routing/index.jsx
@@ -13,6 +13,7 @@ import Titles from '../Pages/Titles'
 import SessionPage from '../Pages/Session'
 import SessionsPage from '../Pages/Sessions'
 import AllSessions from '../Pages/Sessions/All'
+import AddScore from '../Pages/AddScore'
 // import { useDispatch, useSelector } from 'react-redux'
 import Login from '../Pages/Login'
 import Profile from '../Pages/Profile'
@@ -76,7 +77,7 @@ const router = createHashRouter([
             },
             {
                 path: 'add',
-                element: <div>add</div>
+                element: <AddScore />
             },
             {
                 path: 'profile/:id',

--- a/Server/src/routes/v1/scores.route.js
+++ b/Server/src/routes/v1/scores.route.js
@@ -29,13 +29,14 @@ router
   .post(auth('postScores'), validate(scoresValidation.createScore), scoresController.postScore)
   .get(auth('getScores'), validate(scoresValidation.getScores), scoresController.getScores);
 
+
 const upload = multer({ dest: 'uploads/' });
 
 router.route('/ocr').post(upload.single('scoreImage'), (req, res) => {
   const imagePath = req.file.path;
 
-  // Call Python OCR script
-  const py = spawn('python3', ['ocr_piupump.py', imagePath]);
+  const scriptPath = path.join(__dirname, '../../../ocr/ocr_piupump.py');
+  const py = spawn('python3', [scriptPath, imagePath]);
   let data = '';
   py.stdout.on('data', (chunk) => (data += chunk));
   py.on('close', (code) => {


### PR DESCRIPTION
## Summary
- enable uploading scores via OCR script
- wire OCR upload page in router and navbar
- expose OCR endpoint through `ocrScore` client
- fix OCR script path on server

## Testing
- `npm test` *(fails: jest not found)*
- `npm test --silent` in Frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a052e09d88324b61ad82568b1789d