### PR TITLE
Fix link colors

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -7,6 +7,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+a, a:visited {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;


### PR DESCRIPTION
## Summary
- add global anchor styles so links inherit text color and don't look blue/purple

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a071122608324b1fc289f9eb5e1b5