### PR TITLE
Restrict Add Score page to Snaki

### DIFF
--- a/Frontend/src/Components/Navigation/index.jsx
+++ b/Frontend/src/Components/Navigation/index.jsx
@@ -137,7 +137,7 @@ function NavBar() {
               >
                 {pages
                   .filter(
-                    (p) => p !== "Add Score" || localStorage.getItem("token")
+                    (p) => p !== "Add Score" || (user && user.username === "Snaki")
                   )
                   .map((page) => (
                     <MenuItem
@@ -166,7 +166,7 @@ function NavBar() {
             <Box sx={{ flexGrow: 20, display: { xs: "none", md: "flex" } }}>
               {pages
                 .filter(
-                  (p) => p !== "Add Score" || localStorage.getItem("token")
+                  (p) => p !== "Add Score" || (user && user.username === "Snaki")
                 )
                 .map((page) => (
                   <Button

--- a/Frontend/src/Pages/AddScore/index.jsx
+++ b/Frontend/src/Pages/AddScore/index.jsx
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import Section from "../../Components/Layout/Section";
 import { ApiClient } from "../../API/httpService";
 import { Button, Box } from "@mui/material";
+import { useUser } from "../../Components/User";
 
 const apiClient = new ApiClient();
 
 const AddScore = () => {
+  const { user } = useUser();
   const [file, setFile] = useState(null);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -19,6 +21,12 @@ const AddScore = () => {
       .catch(() => setResult(null))
       .finally(() => setLoading(false));
   };
+
+  if (!user || user.username !== "Snaki") {
+    return (
+      <Section header="Add Score">Only Snaki can access this page.</Section>
+    );
+  }
 
   return (
     <Section header="Add Score">


### PR DESCRIPTION
## Summary
- show `Add Score` navigation item only when logged-in user is `Snaki`
- guard Add Score page so that only `Snaki` may access it

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in `Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a084950f48324b91601ede9201369