### PR TITLE
Add share image dialog

### DIFF
--- a/Frontend/src/Components/ShareImageDialog.jsx
+++ b/Frontend/src/Components/ShareImageDialog.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from '@mui/material';
+
+const ShareImageDialog = ({ open, url, onClose }) => {
+  const copy = async () => {
+    if (!url) return;
+    try {
+      if (navigator.clipboard && navigator.clipboard.write) {
+        const blob = await (await fetch(url)).blob();
+        await navigator.clipboard.write([
+          new ClipboardItem({ [blob.type]: blob }),
+        ]);
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(url);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const download = () => {
+    if (!url) return;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'session.png';
+    a.click();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md">
+      <DialogTitle>Share Image</DialogTitle>
+      <DialogContent>
+        {url && (
+          <img
+            src={url}
+            alt="share"
+            style={{ width: '100%', height: 'auto' }}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={copy}>Copy</Button>
+        <Button onClick={download}>Download</Button>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ShareImageDialog;

--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -24,6 +24,7 @@ import styled from "styled-components";
 import { storeSessionId } from "../../helpers/sessionUtils";
 import Logo from "../../Assets/logoSq.png";
 import ScoreDetailsDialog from "../../Components/ScoreDetailsDialog";
+import ShareImageDialog from "../../Components/ShareImageDialog";
 
 const api = new ApiClient();
 
@@ -86,6 +87,7 @@ const SessionPage = () => {
   const [view, setView] = useState("list");
   const [selected, setSelected] = useState(new Set());
   const [openScore, setOpenScore] = useState(null);
+  const [shareUrl, setShareUrl] = useState(null);
   const shareRef = useRef(null);
   const navigate = useNavigate();
   const { user } = useUser();
@@ -156,12 +158,7 @@ const SessionPage = () => {
       useCORS: true,
     });
     const url = canvas.toDataURL("image/png");
-    const win = window.open("");
-    if (win) {
-      const img = new Image();
-      img.src = url;
-      win.document.body.appendChild(img);
-    }
+    setShareUrl(url);
   };
 
   if (!session) return <p>{id ? "Session not found" : "No active session"}</p>;
@@ -452,6 +449,11 @@ const SessionPage = () => {
           onClose={() => setOpenScore(null)}
         />
       </Box>
+      <ShareImageDialog
+        open={!!shareUrl}
+        url={shareUrl}
+        onClose={() => setShareUrl(null)}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- add ShareImageDialog component for image preview
- capture screenshot and open new dialog instead of new window

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3a63bf248324becf38d26ec93d8a