### PR TITLE
Add daily score heatmap

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -40,6 +40,8 @@ export class ApiClient {
     client.get("scores/latestPlayers", { params: { limit } });
   getAllScores = (page, limit, filters = {}, sortBy) =>
     client.get("scores/all", { params: { page, limit, sortBy, ...filters } });
+  getDailyScores = (userId, from, to) =>
+    client.get("scores/daily", { params: { userId, from, to } });
 
   getScoreHistory = (mode, songId, diff, userId) =>
     client.get(`scores/history/${mode}/${songId}/${diff}`, {

--- a/Frontend/src/Components/Heatmap/index.jsx
+++ b/Frontend/src/Components/Heatmap/index.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+`;
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const Cell = styled.div`
+  width: 12px;
+  height: 12px;
+  margin: 1px;
+  background-color: ${({ level }) => ['#ebedf0','#c6e48b','#7bc96f','#239a3b','#196127'][level]};
+`;
+
+const CalendarHeatmap = ({ counts }) => {
+  const today = new Date();
+  const start = new Date(today);
+  start.setDate(start.getDate() - 364);
+  start.setHours(0,0,0,0);
+  const startDay = start.getDay();
+  start.setDate(start.getDate() - startDay);
+
+  const dateKey = (d) => d.toISOString().slice(0,10);
+
+  const days = [];
+  let d = new Date(start);
+  while (d <= today) {
+    days.push({ date: new Date(d), count: counts[dateKey(d)] || 0 });
+    d.setDate(d.getDate() + 1);
+  }
+  const weeks = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+  const max = Math.max(0, ...days.map((dd) => dd.count));
+  const level = (c) => {
+    if (c === 0 || max === 0) return 0;
+    const t = c / max;
+    if (t > 0.75) return 4;
+    if (t > 0.5) return 3;
+    if (t > 0.25) return 2;
+    return 1;
+  };
+  return (
+    <Wrapper>
+      {weeks.map((week, i) => (
+        <Column key={i}>
+          {Array.from({ length: 7 }).map((_, j) => {
+            const day = week[j];
+            const count = day ? day.count : 0;
+            const dt = day ? dateKey(day.date) : '';
+            return <Cell key={j} level={level(count)} title={`${dt}: ${count}`} />;
+          })}
+        </Column>
+      ))}
+    </Wrapper>
+  );
+};
+
+export default CalendarHeatmap;

--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -18,6 +18,7 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import ClearIcon from "@mui/icons-material/Clear";
 import { ApiClient } from "../../API/httpService";
+import CalendarHeatmap from "../../Components/Heatmap";
 import songs from "../../consts/songs.json";
 import compareGrades from "../../helpers/compareGrades";
 import grades from "../../Assets/Grades";
@@ -81,6 +82,7 @@ const Profile = () => {
   const [sessions, setSessions] = useState([]);
   const [rivals, setRivals] = useState([]);
   const [myRivals, setMyRivals] = useState([]);
+  const [dailyCounts, setDailyCounts] = useState({});
   const [showAvatarInput, setShowAvatarInput] = useState(false);
   const [avatarUrlInput, setAvatarUrlInput] = useState("");
   const { user: loggedUser, setUser: setLoggedUser } = useUser();
@@ -124,6 +126,16 @@ const Profile = () => {
     apiClient.getGoals(MODES.DOUBLE, id).then((r) => setDoubleGoals(r.data));
     apiClient.listSessions(id).then((r) => setSessions(r.data));
     apiClient.getRivals(id).then((r) => setRivals(r.data));
+    apiClient
+      .getDailyScores(id)
+      .then((r) => {
+        const obj = {};
+        r.data.forEach((d) => {
+          obj[d.date] = d.count;
+        });
+        setDailyCounts(obj);
+      })
+      .catch(() => {});
     if (loggedUser) {
       apiClient.getRivals().then((r) => setMyRivals(r.data));
     }
@@ -283,6 +295,11 @@ const Profile = () => {
           )}
         </Box>
       </Section>
+      {Object.keys(dailyCounts).length > 0 && (
+        <Section header="Daily activity">
+          <CalendarHeatmap counts={dailyCounts} />
+        </Section>
+      )}
       {sessions.length > 0 && (
         <Section header="Your sessions">
           <Table size="small">

--- a/Server/src/controllers/scores.controller.js
+++ b/Server/src/controllers/scores.controller.js
@@ -28,6 +28,13 @@ const getBestScore = catchAsync(async (req, res) => {
     res.send(score);
 });
 
+const getDailyScores = catchAsync(async (req, res) => {
+    const userId = req.query.userId || req.user.id;
+    const { from, to } = req.query;
+    const data = await scoresService.getDailyScores(userId, from, to);
+    res.send(data);
+});
+
 const postScore = catchAsync(async (req, res) => {
     const result = await scoresService.createScore(req.body, req.params.mode, req.user);
     res.status(httpStatus.CREATED).send(result);
@@ -80,4 +87,5 @@ module.exports = {
     getLatestScores,
     getLatestPlayers,
     getAllScores,
+    getDailyScores,
 };

--- a/Server/src/routes/v1/scores.route.js
+++ b/Server/src/routes/v1/scores.route.js
@@ -13,6 +13,10 @@ router.route('/latestPlayers').get(validate(scoresValidation.getLatestPlayers), 
 router.route('/all').get(validate(scoresValidation.getAllScores), scoresController.getAllScores);
 
 router
+  .route('/daily')
+  .get(auth('getScores'), validate(scoresValidation.getDailyScores), scoresController.getDailyScores);
+
+router
   .route('/history/:mode/:songId/:diff')
   .get(auth('getScores'), validate(scoresValidation.getScoreHistory), scoresController.getScoreHistory);
 

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -184,6 +184,22 @@ const getBestScore = async (mode, songId, diff) => {
   return best;
 };
 
+const getDailyScores = async (userId, from, to) => {
+  const where = [`"userId" = $1`];
+  const params = [userId];
+  if (from) {
+    params.push(new Date(from));
+    where.push(`"createdAt" >= $${params.length}`);
+  }
+  if (to) {
+    params.push(new Date(to));
+    where.push(`"createdAt" <= $${params.length}`);
+  }
+  const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const query = `SELECT DATE("createdAt") AS date, COUNT(*)::int AS count FROM "Score" ${whereClause} GROUP BY DATE("createdAt") ORDER BY DATE("createdAt")`;
+  return prisma.$queryRawUnsafe(query, ...params);
+};
+
 const deleteScore = async (id, userId) => {
   const score = await prisma.score.findUnique({ where: { id } });
   if (!score || score.userId !== userId) return null;
@@ -202,4 +218,5 @@ module.exports = {
   deleteScore,
   getGradeIndex,
   getBestScore,
+  getDailyScores,
 };

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -77,6 +77,14 @@ const getBestScore = {
   }),
 };
 
+const getDailyScores = {
+  query: Joi.object().keys({
+    userId: Joi.string(),
+    from: Joi.date(),
+    to: Joi.date(),
+  }),
+};
+
 module.exports = {
   createScore,
   getScores,
@@ -86,4 +94,5 @@ module.exports = {
   getLatestPlayers,
   getAllScores,
   deleteScore,
+  getDailyScores,
 };


### PR DESCRIPTION
## Summary
- create reusable CalendarHeatmap component
- fetch daily score counts from new `GET /scores/daily` endpoint
- expose `getDailyScores` in API client and show heatmap on user profile
- implement backend route, controller and service to aggregate daily score counts

## Testing
- `npm test` *(fails: react-scripts/jest not found)*
- `npm test` in `Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3a4404008324bf84d1f5ddd832be