### PR TITLE
Add Failed grade

### DIFF
--- a/Frontend/src/Components/GradeDropdown/index.jsx
+++ b/Frontend/src/Components/GradeDropdown/index.jsx
@@ -48,6 +48,9 @@ const GradeDropdown = ({ value, label, onChange, size = "small" }) => {
       <MenuItem value={"F"}>
         <Grade src={grades.F} />
       </MenuItem>
+      <MenuItem value={"Failed"}>
+        <Grade src={grades.Failed} />
+      </MenuItem>
     </Select>
   );
 };

--- a/Frontend/src/Components/GradeSelect/index.jsx
+++ b/Frontend/src/Components/GradeSelect/index.jsx
@@ -5,7 +5,7 @@ import grades from '../../Assets/Grades'
 
 const GradeSelect = ({ value, label, onChange }) => {
     const mainGrades = ['SS', 'S', 'Ap', 'A']
-    const otherGrades = ['SSS', 'Bp', 'Cp', 'Dp', 'B', 'C', 'D', 'F']
+    const otherGrades = ['SSS', 'Bp', 'Cp', 'Dp', 'B', 'C', 'D', 'F', 'Failed']
 
     const otherValue = otherGrades.includes(value) ? value : ''
 

--- a/Frontend/src/Pages/Songs/index.js
+++ b/Frontend/src/Pages/Songs/index.js
@@ -100,7 +100,7 @@ const filterItems = (a, details, mode, diff, hidden, hideScore, tags) => {
     (details[mode][diff] && details[mode][diff][a[0]]?.grade) || undefined;
   if (hidden.pass) {
     if (grade) show = false;
-    if (["A", "B", "C", "D", "F", undefined].includes(grade)) show = true;
+    if (["A", "B", "C", "D", "F", "Failed", undefined].includes(grade)) show = true;
   }
   if (hidden.played) {
     if (grade) show = false;

--- a/Frontend/src/helpers/compareGrades.js
+++ b/Frontend/src/helpers/compareGrades.js
@@ -1,5 +1,5 @@
 // Grade order from best to worst
-// SSS > SS > S > Ap > Bp > Cp > Dp > A > B > C > D > F
+// SSS > SS > S > Ap > Bp > Cp > Dp > A > B > C > D > F > Failed
 const gradeOrder = [
     'SSS',
     'SS',
@@ -13,6 +13,7 @@ const gradeOrder = [
     'C',
     'D',
     'F',
+    'Failed',
 ]
 
 const compareGrades = (a, b) => {

--- a/Server/src/services/achievement.service.js
+++ b/Server/src/services/achievement.service.js
@@ -19,6 +19,7 @@ const gradeOrder = [
   'C',
   'D',
   'F',
+  'Failed',
 ];
 const gradeBetterOrEqual = (a, b) => {
   if (!a) return false;

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -15,6 +15,7 @@ const gradeOrder = [
   'C',
   'D',
   'F',
+  'Failed',
 ];
 
 const passGrades = ['SSS', 'SS', 'S', 'Ap', 'Bp', 'Cp', 'Dp'];


### PR DESCRIPTION
## Summary
- add `Failed` to grade order and scoring logic
- display `Failed` option on grade selectors
- support `Failed` in song filtering and comparison logic

## Testing
- `npm test` *(fails: jest not found)*
- `npm test --silent` in Frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a405fd9908324825e74def90e5f42