### PR TITLE
Fix share checkbox propagation

### DIFF
--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -217,7 +217,11 @@ const SessionPage = () => {
                 <TableCell padding="checkbox">
                   <Checkbox
                     checked={selected.has(s.id)}
-                    onChange={() => toggleSelect(s.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      toggleSelect(s.id);
+                    }}
                   />
                 </TableCell>
                 <TableCell>
@@ -266,7 +270,11 @@ const SessionPage = () => {
             >
               <Checkbox
                 checked={selected.has(s.id)}
-                onChange={() => toggleSelect(s.id)}
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  toggleSelect(s.id);
+                }}
               />
               <Paper
                 onClick={() => setOpenScore(s)}


### PR DESCRIPTION
## Summary
- prevent session score checkbox clicks from triggering row click events

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a41696b40832489bfc99b209377f9