### PR TITLE
Move Daily Activity into user info

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -274,6 +274,12 @@ const Profile = () => {
                 )}
               </Box>
             )}
+            {Object.keys(dailyCounts).length > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="h6">Daily activity</Typography>
+                <CalendarHeatmap counts={dailyCounts} />
+              </Box>
+            )}
           </Box>
         )}
       </Section>
@@ -296,11 +302,6 @@ const Profile = () => {
           )}
         </Box>
       </Section>
-      {Object.keys(dailyCounts).length > 0 && (
-        <Section header="Daily activity">
-          <CalendarHeatmap counts={dailyCounts} />
-        </Section>
-      )}
       {sessions.length > 0 && (
         <Section header="Your sessions">
           <Table size="small">


### PR DESCRIPTION
## Summary
- display daily heatmap at bottom of user info
- remove separate daily activity section

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a46e4fd28832493baef7ab295e8fa