### PR TITLE
Fix heatmap date calculation

### DIFF
--- a/Frontend/src/Components/Heatmap/index.jsx
+++ b/Frontend/src/Components/Heatmap/index.jsx
@@ -46,7 +46,7 @@ const CalendarHeatmap = ({ counts }) => {
   const startDay = start.getDay();
   start.setDate(start.getDate() - startDay);
 
-  const dateKey = (d) => d.toISOString().slice(0,10);
+  const dateKey = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
   const days = [];
   let d = new Date(start);


### PR DESCRIPTION
## Summary
- fix daily heatmap dateKey to use local dates instead of UTC

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `Frontend` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_687a476262e48324907d92d27abe98b6