### PR TITLE
Fix heatmap to start weeks on Monday

### DIFF
--- a/Frontend/src/Components/Heatmap/index.jsx
+++ b/Frontend/src/Components/Heatmap/index.jsx
@@ -49,7 +49,7 @@ const CalendarHeatmap = ({ counts }) => {
   start.setDate(start.getDate() - 364);
   start.setHours(0, 0, 0, 0);
   const startDay = start.getDay();
-  start.setDate(start.getDate() - startDay);
+  start.setDate(start.getDate() - ((startDay + 6) % 7));
 
   const dateKey = (d) =>
     `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
@@ -82,7 +82,7 @@ const CalendarHeatmap = ({ counts }) => {
     if (t > 0.25) return 2;
     return 1;
   };
-  const daysOfWeek = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const daysOfWeek = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
   return (
     <div style={{ display: "flex" }}>
       <DayLabelsWrapper>


### PR DESCRIPTION
## Summary
- adjust `CalendarHeatmap` to display weeks starting on Monday instead of Sunday

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4eaf719c8324be1aacd08c299613