### PR TITLE
Fix avatar add button icon for dark mode

### DIFF
--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -58,6 +58,7 @@ const AddButton = styled(IconButton)`
   bottom: 0;
   right: 0;
   background-color: white !important;
+  color: black !important;
   &:hover {
     background-color: white;
   }


### PR DESCRIPTION
## Summary
- style AddButton icon color so it stays visible with a dark theme

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in `Server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5f6d01ac832493430adf06c38d5f