### PR TITLE
Add chart comments

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -85,6 +85,10 @@ export class ApiClient {
       params: userId ? { userId } : {},
     });
 
+  getComments = (mode, songId, diff) =>
+    client.get(`comments/${mode}/${songId}/${diff}`);
+  postComment = (mode, data) => client.post(`comments/${mode}/${data.song_id}/${data.diff}`, data);
+
   ocrScore = (file) => {
     const data = new FormData();
     data.append("scoreImage", file);

--- a/Frontend/src/Components/CommentsSection.jsx
+++ b/Frontend/src/Components/CommentsSection.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Box, TextField, Button, Typography } from '@mui/material';
+import styled from 'styled-components';
+import { ApiClient } from '../API/httpService';
+import { useUser } from './User';
+
+const CommentsSection = ({ mode, songId, diff }) => {
+  const [comments, setComments] = useState([]);
+  const [text, setText] = useState('');
+  const { user } = useUser();
+  const api = new ApiClient();
+
+  const load = () => {
+    api.getComments(mode, songId, diff).then((r) => setComments(r.data));
+  };
+
+  useEffect(() => {
+    load();
+  }, [mode, songId, diff]);
+
+  const post = () => {
+    if (!text.trim()) return;
+    api
+      .postComment(mode, { song_id: songId, diff, text })
+      .then((r) => {
+        setText('');
+        setComments((c) => [...c, r.data]);
+      });
+  };
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        Comments
+      </Typography>
+      {comments.map((c) => (
+        <CommentItem key={c.id}>
+          <b>{c.user.username}:</b> {c.text}
+        </CommentItem>
+      ))}
+      {user && (
+        <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+          <TextField
+            size="small"
+            fullWidth
+            label="Add a comment"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <Button variant="contained" onClick={post}>
+            Post
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default CommentsSection;
+
+const CommentItem = styled.div`
+  margin-bottom: 4px;
+`;

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -28,6 +28,7 @@ import GradeSelect from "../../Components/GradeSelect";
 import packs from "../../consts/packs";
 import { ApiClient } from "../../API/httpService";
 import ScoreDetailsDialog from "../../Components/ScoreDetailsDialog";
+import CommentsSection from "../../Components/CommentsSection";
 
 const SongDetails = ({
   chart,
@@ -327,6 +328,7 @@ const SongDetails = ({
             </Accordion>
           </>
         )}
+        <CommentsSection mode={chart.mode} songId={chart.id} diff={chart.diff} />
       </Content>
       <ScoreDetailsDialog
         open={!!openScore}

--- a/Server/prisma/migrations/20250720000000_add_comments_table/migration.sql
+++ b/Server/prisma/migrations/20250720000000_add_comments_table/migration.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "Comment" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "song_id" TEXT NOT NULL,
+    "diff" TEXT NOT NULL,
+    "mode" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Comment_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -114,3 +114,14 @@ model Rival {
 
   @@unique([userId, rivalId])
 }
+
+model Comment {
+  id        Int      @id @default(autoincrement())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  song_id   String
+  diff      String
+  mode      String
+  text      String
+  createdAt DateTime @default(now())
+}

--- a/Server/src/controllers/comments.controller.js
+++ b/Server/src/controllers/comments.controller.js
@@ -1,0 +1,17 @@
+const httpStatus = require('http-status');
+const catchAsync = require('../utils/catchAsync');
+const { commentsService } = require('../services');
+
+const postComment = catchAsync(async (req, res) => {
+  const mode = req.params.mode;
+  const comment = await commentsService.createComment(req.body, mode, req.user);
+  res.status(httpStatus.CREATED).send(comment);
+});
+
+const getComments = catchAsync(async (req, res) => {
+  const { mode, songId, diff } = req.params;
+  const comments = await commentsService.getComments(mode, songId, diff);
+  res.send(comments);
+});
+
+module.exports = { postComment, getComments };

--- a/Server/src/controllers/index.js
+++ b/Server/src/controllers/index.js
@@ -7,3 +7,4 @@ module.exports.ratingsController = require('./ratings.controller');
 module.exports.goalsController = require('./goals.controller');
 module.exports.sessionsController = require('./sessions.controller');
 module.exports.rivalsController = require('./rivals.controller');
+module.exports.commentsController = require('./comments.controller');

--- a/Server/src/routes/v1/comments.route.js
+++ b/Server/src/routes/v1/comments.route.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const auth = require('../../middlewares/auth');
+const validate = require('../../middlewares/validate');
+const commentsValidation = require('../../validations/comments.validation');
+const commentsController = require('../../controllers/comments.controller');
+
+const router = express.Router();
+
+router
+  .route('/:mode/:songId/:diff')
+  .get(commentsController.getComments)
+  .post(
+    auth('postScores'),
+    validate(commentsValidation.postComment),
+    commentsController.postComment,
+  );
+
+module.exports = router;

--- a/Server/src/routes/v1/index.js
+++ b/Server/src/routes/v1/index.js
@@ -10,6 +10,7 @@ const goalsRoute = require('./goals.route');
 const sessionsRoute = require('./sessions.route');
 const rivalsRoute = require('./rivals.route');
 const ocrRoute = require('./ocr.route');
+const commentsRoute = require('./comments.route');
 const config = require('../../config/config');
 
 const router = express.Router();
@@ -50,6 +51,10 @@ const defaultRoutes = [
   {
     path: '/rivals',
     route: rivalsRoute,
+  },
+  {
+    path: '/comments',
+    route: commentsRoute,
   },
   {
     path: `/ocr`,

--- a/Server/src/services/comments.service.js
+++ b/Server/src/services/comments.service.js
@@ -1,0 +1,24 @@
+const prisma = require('../db');
+
+const createComment = async (data, mode, user) => {
+  const { song_id, diff, text } = data;
+  return prisma.comment.create({
+    data: {
+      userId: user.id,
+      song_id,
+      diff,
+      mode,
+      text,
+    },
+    include: { user: { select: { username: true } } },
+  });
+};
+
+const getComments = async (mode, song_id, diff) =>
+  prisma.comment.findMany({
+    where: { mode, song_id, diff },
+    orderBy: { id: 'asc' },
+    include: { user: { select: { username: true } } },
+  });
+
+module.exports = { createComment, getComments };

--- a/Server/src/services/index.js
+++ b/Server/src/services/index.js
@@ -10,3 +10,4 @@ module.exports.ratingsService = require('./ratings.service');
 module.exports.goalsService = require('./goals.service');
 module.exports.sessionService = require('./session.service');
 module.exports.rivalsService = require('./rivals.service');
+module.exports.commentsService = require('./comments.service');

--- a/Server/src/validations/comments.validation.js
+++ b/Server/src/validations/comments.validation.js
@@ -1,0 +1,11 @@
+const Joi = require('joi');
+
+const postComment = {
+  body: Joi.object().keys({
+    song_id: Joi.string().required(),
+    diff: Joi.string().required(),
+    text: Joi.string().min(1).required(),
+  }),
+};
+
+module.exports = { postComment };


### PR DESCRIPTION
## Summary
- allow backend to store comments per chart
- support posting and retrieving comments via API
- add comments section to song details view

## Testing
- `npm test` *(fails: jest not found)*
- `npm test --silent` in Frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e358784e483248bf3d4052199082b