### PR TITLE
Add score comments and CSV export

### DIFF
--- a/Frontend/src/API/httpService.js
+++ b/Frontend/src/API/httpService.js
@@ -52,6 +52,10 @@ export class ApiClient {
     client.get(`scores/best/${mode}/${songId}/${diff}`);
 
   deleteScore = (id) => client.delete(`scores/${id}`);
+  updateScore = (id, comment) => client.patch(`scores/${id}`, { comment });
+  exportScores = (userId) => client.get('scores/export', { params: { userId }, responseType: 'blob' });
+
+  exportSession = (id) => client.get(`sessions/${id}/export`, { responseType: 'blob' });
 
   getGoals = (mode, userId) =>
     client.get(`goals/${mode}`, { params: userId ? { userId } : {} });

--- a/Frontend/src/Components/ScoreDetailsDialog.jsx
+++ b/Frontend/src/Components/ScoreDetailsDialog.jsx
@@ -31,6 +31,7 @@ const ScoreDetailsDialog = ({ open, onClose, score }) => {
             {row('Bad', score.bad)}
             {row('Misses', score.misses)}
             {row('Max Combo', score.combo)}
+            {row('Comment', score.comment)}
           </TableBody>
         </Table>
       </DialogContent>

--- a/Frontend/src/Pages/Profile/index.jsx
+++ b/Frontend/src/Pages/Profile/index.jsx
@@ -113,6 +113,17 @@ const Profile = () => {
     });
   };
 
+  const handleExport = () => {
+    apiClient.exportScores(id).then((r) => {
+      const url = window.URL.createObjectURL(new Blob([r.data]));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'scores.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  };
+
   useEffect(() => {
     if (!id) return;
     apiClient.getUser(id).then((r) => {
@@ -257,6 +268,13 @@ const Profile = () => {
             <Typography sx={{ mt: 1 }}>
               <Link to="/Titles">Titles info</Link>
             </Typography>
+            {isOwnProfile && (
+              <Box sx={{ mt: 1 }}>
+                <Button size="small" onClick={handleExport}>
+                  Export Scores
+                </Button>
+              </Box>
+            )}
             {!isOwnProfile && loggedUser && (
               <Box sx={{ mt: 1 }}>
                 <Button

--- a/Frontend/src/Pages/Session/index.jsx
+++ b/Frontend/src/Pages/Session/index.jsx
@@ -161,6 +161,18 @@ const SessionPage = () => {
     setShareUrl(url);
   };
 
+  const exportCsv = () => {
+    const sid = id || session.id;
+    api.exportSession(sid).then((r) => {
+      const url = window.URL.createObjectURL(new Blob([r.data]));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'session.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  };
+
   if (!session) return <p>{id ? "Session not found" : "No active session"}</p>;
 
   return (
@@ -182,10 +194,11 @@ const SessionPage = () => {
           </Button>
         </Box>
       )}
-      <Box sx={{ mb: 2 }}>
+      <Box sx={{ mb: 2, display: 'flex', gap: 1 }}>
         <Button onClick={share} variant="contained" startIcon={<ShareIcon />}>
           Share
         </Button>
+        <Button onClick={exportCsv} variant="outlined">Export CSV</Button>
       </Box>
       <ToggleButtonGroup
         value={view}

--- a/Frontend/src/Pages/Songs/SongDetails.jsx
+++ b/Frontend/src/Pages/Songs/SongDetails.jsx
@@ -19,6 +19,7 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ClearIcon from "@mui/icons-material/Clear";
+import NoteAltIcon from "@mui/icons-material/NoteAlt";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import grades from "../../Assets/Grades";
@@ -53,6 +54,7 @@ const SongDetails = ({
   const [miss, setMiss] = useState(0);
   const [combo, setCombo] = useState(0);
   const [total, setTotal] = useState(0);
+  const [comment, setComment] = useState("");
   const apiClient = useMemo(() => new ApiClient(), []);
 
   useEffect(() => {
@@ -157,6 +159,7 @@ const SongDetails = ({
             <TextField label="Misses" size="small" type="number" value={miss} onChange={(e) => setMiss(e.target.value)} />
             <TextField label="Max Combo" size="small" type="number" value={combo} onChange={(e) => setCombo(e.target.value)} />
             <TextField label="Total Score" size="small" type="number" value={total} onChange={(e) => setTotal(e.target.value)} />
+            <TextField label="Comment" size="small" value={comment} onChange={(e) => setComment(e.target.value)} />
             <Button
               variant="contained"
               size="small"
@@ -172,8 +175,9 @@ const SongDetails = ({
                     bad: Number(bad),
                     misses: Number(miss),
                     combo: Number(combo),
-                  total: Number(total),
-                })
+                    total: Number(total),
+                    comment,
+                  })
                   .then(() => {
                     setShowAccurate(false);
                     changeGrade && changeGrade(grade, true);
@@ -286,9 +290,10 @@ const SongDetails = ({
                     <TableRow>
                       <TableCell>Grade</TableCell>
                       <TableCell>Date / Time</TableCell>
+                      {removeScore && <TableCell>Notes</TableCell>}
                       {removeScore && <TableCell />}
                     </TableRow>
-                  </TableHead>
+                 </TableHead>
                   <TableBody>
                     {history.map((h) => (
                       <TableRow
@@ -313,11 +318,24 @@ const SongDetails = ({
                           {new Date(h.createdAt).toLocaleString()}
                         </TableCell>
                         {removeScore && (
-                          <TableCell>
-                            <IconButton size="small" onClick={() => removeScore(h.id)}>
-                              <ClearIcon fontSize="small" />
-                            </IconButton>
-                          </TableCell>
+                          <>
+                            <TableCell>
+                              <IconButton size="small" onClick={(e) => {
+                                e.stopPropagation();
+                                const val = window.prompt('Comment', h.comment || '');
+                                if (val !== null) apiClient.updateScore(h.id, val).then(() => {
+                                  h.comment = val;
+                                });
+                              }}>
+                                <NoteAltIcon fontSize="small" />
+                              </IconButton>
+                            </TableCell>
+                            <TableCell>
+                              <IconButton size="small" onClick={() => removeScore(h.id)}>
+                                <ClearIcon fontSize="small" />
+                              </IconButton>
+                            </TableCell>
+                          </>
                         )}
                       </TableRow>
                     ))}

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Score {
   misses    Int?
   combo     Int?
   total     Int?
+  comment   String?
   mode      String
   createdAt DateTime @default(now())
   firstPass Boolean  @default(false)

--- a/Server/src/controllers/sessions.controller.js
+++ b/Server/src/controllers/sessions.controller.js
@@ -54,6 +54,31 @@ const deleteSession = catchAsync(async (req, res) => {
   }
   res.status(httpStatus.NO_CONTENT).send();
 });
+
+const exportSession = catchAsync(async (req, res) => {
+  const session = await sessionService.getSession(req.params.id);
+  if (!session) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Session not found');
+  }
+  const lines = ['date,song,diff,mode,grade,miss_count,is_new_clear,is_fail,notes'];
+  session.scores.forEach((s) => {
+    const fail = s.grade === 'Failed' || s.grade === 'F';
+    lines.push([
+      s.createdAt.toISOString(),
+      s.song_id,
+      s.diff,
+      s.mode,
+      s.grade || '',
+      s.misses ?? '',
+      s.firstPass ? 'true' : 'false',
+      fail ? 'true' : 'false',
+      s.comment ? s.comment.replace(/\n/g, ' ') : ''
+    ].join(','));
+  });
+  res.header('Content-Type', 'text/csv');
+  res.attachment('session.csv');
+  res.send(lines.join('\n'));
+});
 module.exports = {
   getCurrent,
   endSession,
@@ -63,4 +88,5 @@ module.exports = {
   listSessions,
   getSession,
   deleteSession,
+  exportSession,
 };

--- a/Server/src/routes/v1/scores.route.js
+++ b/Server/src/routes/v1/scores.route.js
@@ -23,6 +23,9 @@ router
 router.route('/best/:mode/:songId/:diff').get(validate(scoresValidation.getBestScore), scoresController.getBestScore);
 
 router.route('/:id').delete(auth('postScores'), validate(scoresValidation.deleteScore), scoresController.deleteScore);
+router.route('/:id').patch(auth('postScores'), validate(scoresValidation.updateScore), scoresController.updateScore);
+
+router.route('/export').get(auth('getScores'), scoresController.exportScores);
 
 router
   .route('/:mode')

--- a/Server/src/routes/v1/sessions.route.js
+++ b/Server/src/routes/v1/sessions.route.js
@@ -21,6 +21,7 @@ router.get(
 );
 router.get('/', auth('getScores'), sessionsController.listSessions);
 router.get('/:id', validate(sessionsValidation.getSession), sessionsController.getSession);
+router.get('/:id/export', validate(sessionsValidation.getSession), sessionsController.exportSession);
 router.delete('/:id', auth('postScores'), validate(sessionsValidation.deleteSession), sessionsController.deleteSession);
 
 module.exports = router;

--- a/Server/src/services/scores.service.js
+++ b/Server/src/services/scores.service.js
@@ -42,7 +42,7 @@ const getScores = async (filter) => {
 };
 
 const createScore = async (scoreBody, mode, user) => {
-  const { song_id, diff, grade, perfects, greats, good, bad, misses, combo, total } = scoreBody;
+  const { song_id, diff, grade, perfects, greats, good, bad, misses, combo, total, comment } = scoreBody;
   let firstPass = false;
   if (grade && passGrades.includes(grade)) {
     const existing = await prisma.score.findFirst({
@@ -68,6 +68,7 @@ const createScore = async (scoreBody, mode, user) => {
       misses: misses ?? null,
       combo: combo ?? null,
       total: total ?? null,
+      comment: comment ?? null,
       userId: user.id,
       mode,
       firstPass,
@@ -210,6 +211,12 @@ const deleteScore = async (id, userId) => {
   return score;
 };
 
+const updateScore = async (id, userId, comment) => {
+  const score = await prisma.score.findUnique({ where: { id } });
+  if (!score || score.userId !== userId) return null;
+  return prisma.score.update({ where: { id }, data: { comment } });
+};
+
 module.exports = {
   getScores,
   createScore,
@@ -218,6 +225,7 @@ module.exports = {
   getAllScores,
   getScoreHistory,
   deleteScore,
+  updateScore,
   getGradeIndex,
   getBestScore,
   getDailyScores,

--- a/Server/src/validations/scores.validation.js
+++ b/Server/src/validations/scores.validation.js
@@ -15,6 +15,7 @@ const createScore = {
     misses: Joi.number().integer().allow(null),
     combo: Joi.number().integer().allow(null),
     total: Joi.number().integer().allow(null),
+    comment: Joi.string().allow('', null),
   }),
 };
 
@@ -69,6 +70,15 @@ const deleteScore = {
   }),
 };
 
+const updateScore = {
+  params: Joi.object().keys({
+    id: Joi.number().integer().required(),
+  }),
+  body: Joi.object().keys({
+    comment: Joi.string().allow('', null).required(),
+  }),
+};
+
 const getBestScore = {
   params: Joi.object().keys({
     mode: Joi.string(),
@@ -95,5 +105,6 @@ module.exports = {
   getLatestPlayers,
   getAllScores,
   deleteScore,
+  updateScore,
   getDailyScores,
 };


### PR DESCRIPTION
## Summary
- allow attaching comments to scores and edit them
- generate CSV exports for user profiles and sessions
- expose endpoints for updating scores and exporting data
- show comment field when adding accurate scores
- add notes icon for editing score comments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e353a41d0832485a7cad111fc1e96