### PR TITLE
Fix missing comment column in scores table

### DIFF
--- a/Server/prisma/migrations/20250721000000_add_score_comment/migration.sql
+++ b/Server/prisma/migrations/20250721000000_add_score_comment/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Score" ADD COLUMN "comment" TEXT;


### PR DESCRIPTION
## Summary
- add Prisma migration to create `Score.comment` column

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687e3b7ea1348324857e9090a36ed999